### PR TITLE
`near` package was renamed to `neard`

### DIFF
--- a/docs/contribution/nearcore.md
+++ b/docs/contribution/nearcore.md
@@ -29,8 +29,8 @@ cd nearcore
 Navigate to the root of the repository, and run:
 
 ```bash
-cargo run --package near -- init
-cargo run --package near -- run
+cargo run --package neard --bin near -- init
+cargo run --package neard --bin near -- run
 ```
 
 This will setup a local chain with `init` and will run the node.


### PR DESCRIPTION
Update the commands to setup and run the chain