### PR TITLE
Add Stake Wars references to staking pages

### DIFF
--- a/docs/validator/staking-overview.md
+++ b/docs/validator/staking-overview.md
@@ -14,7 +14,17 @@ The protocol automatically elects validators by issuing an auction for each epoc
 
 **Important** to note: As a validator you do not have to know about the underlying blockchain infrastructure. Once you have set-up a validator node, it runs all processes automatically. Meaning, that you do not have to interfere with the node and you are only required to set up one node to start validating.
 
-## The Process
+## Heads up! Stake Wars is back!
+
+Stake Wars is NEAR's incentivized testnet for professional validators.
+
+NEAR’s [MainNet](https://explorer.near.org/) recently launched into its first phase, called “POA” ([see full roadmap](https://near.ai/mainnet-roadmap)). This means that a small handful of validating nodes are currently being run by the core team. In order to progress to the next phase, “MainNet: Restricted”, the operation of the network will be handed off to a large group of node operators called validators. 
+
+The goal of Stake Wars: Episode II is to onboard those validators, test the stability of the system, and begin introducing some of the unique aspects of NEAR’s delegation in preparation for the next phase of MainNet itself.
+
+If you want to know more about this opportunity, read the [Stake Wars Episode II blog post](https://near.org/blog/stake-wars-episode-ii/).
+
+## The Process to Become Validator
 
 1. Understand the economics of Proof of Stake, and how do they work for NEAR validators. Please go to the economics section on [Economics of a Validator](../validator/economics.md)
 

--- a/docs/validator/staking.md
+++ b/docs/validator/staking.md
@@ -121,6 +121,12 @@ You should see a success message that looks something like:
 Staking 50000 on thefutureisnear with public key = A4inyaard6yzt1HQL8u5BYdWhWQgCB87RbRRHKPepfrn.
 ```
 
+<blockquote class="warning">
+    <strong>heads up</strong><br><br>
+    NEAR Protocol provides contract-based delegation. Take some time to learn more, reading the Stake Wars Ep.II <a href="https://near.org/blog/stake-wars-episode-ii/" target="_blank">blog post</a>.
+</blockquote>
+
+
 ## Being chosen to become a validator
 
 After this, you will need to wait the ~6 hours bonding period on BetaNet to see if you have staked enough to become a validator. You can see you are a validator when in the logs of the node you see "V/" - where V means this node is currently a validator.


### PR DESCRIPTION
Added a few contents and links, mostly coming from the Stake Wars github readme, to provide a bridge between website visitors and Stake Wars