### PR TITLE
Hotfix/363 remove broken windows instructions

### DIFF
--- a/docs/local-setup/local-dev-node.md
+++ b/docs/local-setup/local-dev-node.md
@@ -51,7 +51,7 @@ sidebar_label: Local Development on Local Network
 
 ## 1. **Run a node locally**
 
-For this step, please refer to the documentation on [running a node on testnet](../local-setup/local-dev-testnet.md) (Linux/MacOS) or the documentation on [running a node on Windows](../local-setup/local-dev-testnet.md). Follow the steps and once your node is running come back to this part of the docs for step 2.
+For this step, please refer to the documentation on [running a node on testnet](../local-setup/local-dev-testnet.md). Follow the steps and once your node is running come back to this part of the docs for step 2.
 
 ## 2. Create an account and start the node
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -83,8 +83,7 @@
     "Machine Setup": [
       "local-setup/local-dev-testnet",
       "local-setup/local-dev-node",
-      "local-setup/running-testnet",
-      "local-setup/running-testnet-windows"
+      "local-setup/running-testnet"
     ],
     "FAQ": [
       "roles/developer/faq"


### PR DESCRIPTION
At this point I think we need to get these errant instructions off of docs.
My experience with `nearup` on my PC wasn't successful. We can try to recommend WSL, but also I think Docker is another issue to look into. It's possible with Windows Professional and Enterprise, although I still ran into issues. Possibly we can tell them to use WSL (or should we recommend WSL 2 now?) with `--nodocker`.
This is an enhancement, in my opinion, and we simply need to remove incorrect instructions. So this somewhat addresses:
https://github.com/near/docs/issues/363
but we need to circle back on this if we feel like this is actually a priority from our community.