### PR TITLE
remove reference to old zero to hero tutorial from intro

### DIFF
--- a/docs/roles/developer/tutorials/introduction.md
+++ b/docs/roles/developer/tutorials/introduction.md
@@ -13,15 +13,6 @@ All of these tutorials are accessible to anyone with some background in software
 
 ## Guided Walkthroughs
 
-### [Zero to Hero (START HERE)](/docs/tutorials/zero-to-hero)
-
-*Build a simple Oracle that can query external APIs and provide this data to the blockchain.*
-
-| duration | directions | difficulty |
-| :------- | :--------- | :--------- |
-| 90 mins  | 7 steps    | Moderate   |
-
-
 ### [Issue a token](/docs/tutorials/near-studio/token)
 
 *Launch a new ERC-20 token on the NEAR blockchain which supports balance checks and transfers*


### PR DESCRIPTION
Noticed that while we had removed the Zero to Hero guide because it's outdated and will cause issues, there was a reference in the introduction. Removed that.