### PR TITLE
Temporarily take down node upgrade page

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -98,8 +98,7 @@
       "validator/staking",
       "validator/keys",
       "validator/maintenance",
-      "validator/economics",
-      "validator/how-to-upgrade"
+      "validator/economics"
     ],
     "FAQ": [
       "validator/validator-faq"


### PR DESCRIPTION
Take down the node upgrade page for now as the zero-downtime upgrade doesn't quite work.