### PR TITLE
typos / dead links removed

### DIFF
--- a/docs/roles/developer/building.md
+++ b/docs/roles/developer/building.md
@@ -16,7 +16,7 @@ The fastest way to get started is to use [NEAR Examples](http://near.dev).
 
 ## First Steps
 
-- Use [NEAR Examples](http://near.dev/) to deploy one of several sample applications in minutes. Explore 
+- Explore [NEAR Examples](http://near.dev/) to deploy one of several sample applications in minutes.
 - Use your own development environment to create dApps
   - Beginner: [TestNet](/docs/local-setup/local-dev-testnet)
   - Advanced: [Local Node](/docs/local-setup/local-dev-node) (independent of TestNet)
@@ -26,8 +26,7 @@ The fastest way to get started is to use [NEAR Examples](http://near.dev).
   - Prepare your developer playground (a single HTML file with inline JavaScript)
   - Explore levels of abstraction in `near-api-js`
   - Send yourself money (after hacking on our wallet storage to learn how it works)
-- Follow our end-to-end guided walkthroughs to
-  - [Zero to Hero](/docs/tutorials/zero-to-hero)
+- Follow our end-to-end guided walkthroughs
   - [Issue a token](/docs/tutorials/near-studio/token)
   - [Call one smart contract from another](/docs/tutorials/how-to-write-contracts-that-talk-to-each-other)
   - [Test smart contracts](/docs/tutorials/test-your-smart-contracts)
@@ -45,10 +44,10 @@ We recommend developers build smart contracts using the Rust programming languag
 
 - [Rust Smart Contracts](/docs/roles/developer/contracts/near-sdk-rs): `near-sdk-rs` provides improved safety with the Rust programming language for high value contracts.
 
-- [Workshop: MapReduce with Asynchronous Smart Contracts](https://github.com/nearprotocol/workshop)  \
-  3 exercises and a challenge that will introduce you to development of smart contracts on the NEAR platform using the Rust programming language.
+<!-- - *** Temporarily removed until workshop is updated and republished ***
 
-
+[Workshop: MapReduce with Asynchronous Smart Contracts](https://github.com/nearprotocol/workshop)  \
+  3 exercises and a challenge that will introduce you to development of smart contracts on the NEAR platform using the Rust programming language. -->
 
 ### Using `AssemblyScript`
 
@@ -68,4 +67,3 @@ If you have feedback or suggestions for improvement, please don't keep quiet abo
 - Find us on [Discord](http://near.chat) or [Spectrum](https://spectrum.chat/near).
 - All our code is open source on [GitHub](https://github.com/nearprotocol).
 - For documentation feedback please file [issues](https://github.com/nearprotocol/docs/issues) on our docs repo or submit a [pull request](https://github.com/nearprotocol/docs/pulls) with your edits.
-

--- a/docs/roles/developer/contracts/rust.md
+++ b/docs/roles/developer/contracts/rust.md
@@ -16,7 +16,9 @@ If you're thinking of invoking a smart contract from Rust then you're likely doi
 
 - [several examples](https://github.com/near/near-sdk-rs/tree/master/examples) are included in the `near-sdk-rs` repo
 
-- In 2019 we held a workshop called [MapReduce with Asynchronous Smart Contracts](https://github.com/nearprotocol/workshop) that included 3 exercises of increasing difficulty and a challenge.  Solutions to the 3 exercises include unit tests.
+<!-- - *** Temporarily removed until workshop is updated and republished ***
+
+In 2019 we held a workshop called [MapReduce with Asynchronous Smart Contracts](https://github.com/nearprotocol/workshop) that included 3 exercises of increasing difficulty and a challenge.  Solutions to the 3 exercises include unit tests. -->
 
 ### Invoking smart contracts from a Rust application outside of NEAR
 


### PR DESCRIPTION
Fixes: #406 

Minor typos and dead tutorials removed.

CI is expected to fail until PR #408 is merged.