### PR TITLE
remove scroll-nav-into-view.js and reference

### DIFF
--- a/docs/roles/developer/contracts/shell.md
+++ b/docs/roles/developer/contracts/shell.md
@@ -4,8 +4,6 @@ title: NEAR Shell
 sidebar_label: NEAR Shell
 ---
 
-
-
 ## Install NEAR Shell
 
 ```sh
@@ -41,7 +39,7 @@ On this page we use the symbol `_???_` to represent whatever is unique to **your
 
 At this point one of two things has happened depending on the contents of the folder where you ran `near login`.
 
-**(A) If you were in a project** created using `create-near-app` for example ([see here for more details](https://docs.near.org/docs/quick-start/create-near-app)) then you will have a `neardev` subfolder with the private key providing full access to the account you just authorized for use with NEAR Shell
+**(A) If you were in a project** created using `create-near-app` for example ([see here for more details](https://www.npmjs.com/package/create-near-app)) then you will have a `neardev` subfolder with the private key providing full access to the account you just authorized for use with NEAR Shell
 
 ```text
 neardev

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -147,7 +147,6 @@ const siteConfig = {
     "https://buttons.github.io/buttons.js",
     "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
     "https://use.fontawesome.com/221fd444f5.js",
-    "/js/scroll-nav-into-view.js",
     "/js/copy-code-button.js",
     // '/js/hotjar.js'
   ],

--- a/website/static/js/scroll-nav-into-view.js
+++ b/website/static/js/scroll-nav-into-view.js
@@ -1,7 +1,0 @@
-window.addEventListener('load', function() {
-  const element = document.querySelector(".navListItemActive")
-
-  if(element) {
-    element.scrollIntoView({behavior: "smooth", block: "end", inline: "nearest"});
-  }
-})


### PR DESCRIPTION
I played with this for about 45 minutes and decided to just remove an extra JavaScript file we have here. This file is aiming to scroll to the left sidebar so the person can see which item is highlighted. However, it interferes with anchors.
I think it's very important to have anchors scroll to their designated positions.
I couldn't find a good solution to have both, let's just ditch the sidebar scrolling and get back the expected anchor scrolling.
So check this version:
https://docs-pr-415.onrender.com/docs/local-setup/running-testnet#success-message
with the same page live:
http://docs.near.org/docs/local-setup/running-testnet#success-message
and you'll see the behavior I'm talking about.