### PR TITLE
remove application renaming step

### DIFF
--- a/docs/tutorials/intro-to-rust.md
+++ b/docs/tutorials/intro-to-rust.md
@@ -26,7 +26,8 @@ run `source $HOME/.cargo/env`
 
 ### 3. Add wasm target to your toolchain
 
-`rustup target add wasm32-unknown-unknown`
+run `rustup target add wasm32-unknown-unknown`
+
 
 <blockquote class="info">
   <a href="https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/webassembly-support.html" target="_blank">Why <code>unknown-unknown</code>?</a>

--- a/docs/tutorials/test-your-smart-contracts.md
+++ b/docs/tutorials/test-your-smart-contracts.md
@@ -207,16 +207,6 @@ window.contract = await near.loadContract(nearConfig.contractName, {
 });
 ```
 
-Next, lets rename the sample application to match what we're working on. Later when we launch this application, we will be prompted to sign in to our NEAR Wallet. Renaming it here will allow us to see a more meaningful authentication request.
-
-> In the file `src/main.js`
-> - Change the name of the application on line 33 to 'NEAR Place'
-
-```js
-// find this line and change it to match
-walletAccount.requestSignIn(nearConfig.contractName, 'NEAR Place');
-```
-
 Now lets write the "NEAR Place" application code.
 
 > In the same file `src/main.js`


### PR DESCRIPTION
"Test your smart contract" tutorial had a step to name your application that would identify the app requesting access in the NEAR wallet. This code is deprecated and therefore step was removed from tutorial.