### PR TITLE
remove / rename mentions of devnet

### DIFF
--- a/docs/api/rpc-experimental.md
+++ b/docs/api/rpc-experimental.md
@@ -21,7 +21,7 @@ This page refers to a **technical preview**.
 Using block hash as `block_id`
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
     method=EXPERIMENTAL_changes_in_block \
     'params:={
         "block_id": "RECENT BLOCK HASH HERE"
@@ -31,7 +31,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
 Using block identifier as `block_id`
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
     method=EXPERIMENTAL_changes_in_block \
     'params:={
         "block_id": 1
@@ -41,7 +41,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
 Using finality instead of `block_id`
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
     method=EXPERIMENTAL_changes_in_block \
     'params:={
         "finality": "optimistic"
@@ -101,7 +101,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
 When an account gets modified (created, updated, removed), we can query the block which contains the receipts for the transaction:
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
     method=EXPERIMENTAL_changes \
     'params:={
         "block_id": 1,
@@ -168,7 +168,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
 When some key gets modified (created, updated, removed), we can query the block which contains the receipts for the transaction:
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
     method=EXPERIMENTAL_changes \
     'params:={
         "block_id": 1,
@@ -237,7 +237,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
 - params: none
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
           method=EXPERIMENTAL_genesis_config
 ```
 
@@ -253,7 +253,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
             0
         ],
         "block_producer_kickout_threshold": 90,
-        "chain_id": "devnet",
+        "chain_id": "testnet",
         "chunk_producer_kickout_threshold": 60,
         "config_version": 1,
         "developer_reward_percentage": 30,
@@ -486,7 +486,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
 If you pass empty parameters, you will get the default pagination, which is offset 0 and limit 100.
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
           method=EXPERIMENTAL_genesis_records \
           'params:={}'
 ```
@@ -494,7 +494,7 @@ http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
 Yet, you have control over the pagination:
 
 ```bash
-http post https://rpc.devnet.near.org jsonrpc=2.0 id=dontcare \
+http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare \
           method=EXPERIMENTAL_genesis_records \
           'params:={"pagination": {"offset": 1, "limit": 2}}'
 ```

--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -10,13 +10,13 @@ NEAR Protocol runs on a collection of publicly maintained computers (or "nodes")
 
 You may decide to run a node of your own for a few reasons:
 
-- To develop and deploy contracts on a node connected to `TestNet`, `BetaNet` or `DevNet` (†)
+- To develop and deploy contracts on a node connected to `TestNet` or `BetaNet` (†)
 - To develop and deploy contracts on a local (independent and isolated) node (sometimes called "LocalNet"). (††)
 - To join a network as a validator running a "validator node" (see [staking](/docs/validator/staking))
 
-_( † ) `TestNet` is intended to operate as closely (similarly) to `MainNet`  as possible with only stable releases while `BetaNet` follows a weekly release cycle.  `DevNet` should be considered cutting edge and unstable._
+_( † ) `TestNet` is intended to operate as closely (similarly) to `MainNet`  as possible with only stable releases while `BetaNet` follows a weekly release cycle._
 
-_( †† ) `LocalNet` would be the right choice if you prefer to avoid leaking information about your work during the development process since `TestNet`, `BetaNet` and `DevNet` are *public* networks. `LocalNet` also gives you total control over accounts, economics and other factors for more advanced use cases (ie. making changes to `nearcore`)._
+_( †† ) `LocalNet` would be the right choice if you prefer to avoid leaking information about your work during the development process since `TestNet` and `BetaNet` are *public* networks. `LocalNet` also gives you total control over accounts, economics and other factors for more advanced use cases (ie. making changes to `nearcore`)._
 
 ## `nearup` Installation
 

--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -10,7 +10,7 @@ NEAR Protocol runs on a collection of publicly maintained computers (or "nodes")
 
 You may decide to run a node of your own for a few reasons:
 
-- To develop and deploy contracts on a node connected to `TestNet` or `BetaNet` (†)
+- To develop and deploy contracts on a node connected to `MainNet`, `TestNet` or `BetaNet` (†)
 - To develop and deploy contracts on a local (independent and isolated) node (sometimes called "LocalNet"). (††)
 - To join a network as a validator running a "validator node" (see [staking](/docs/validator/staking))
 

--- a/docs/quick-start/development-overview.md
+++ b/docs/quick-start/development-overview.md
@@ -156,7 +156,7 @@ If you want to specify a name for you contract, you can do that in config.js. Th
 
 ```javascript
 (function() {
-  const CONTRACT_NAME = 'near-hello-devnet'; /* TODO: fill this in! */
+  const CONTRACT_NAME = 'near-hello-testnet'; /* TODO: fill this in! */
   const DEFAULT_ENV = 'development';
 [...]
 ```
@@ -212,12 +212,12 @@ This is the entry point for any js for your application. For a small application
 async function initContract() {
   console.log("nearConfig", nearConfig);
 
-  // Initializing connection to the NEAR DevNet.
-  window.near = await nearApi.connect(Object.assign({ deps: { keyStore: new nearApi.keyStores.BrowserLocalStorageKeyStore() } }, nearConfig));
+  // Initializing connection to the NEAR testnet.
+  window.near = await nearAPI.connect(Object.assign({ deps: { keyStore: new nearAPI.keyStores.BrowserLocalStorageKeyStore() } }, nearConfig));
 
-  // Initializing Wallet based Account. It can work with NEAR DevNet wallet that
+  // Initializing Wallet based Account. It can work with NEAR testnet wallet that
   // is hosted at https://wallet.testnet.near.org
-  window.walletAccount = new nearApi.WalletAccount(window.near);
+  window.walletAccount = new nearAPI.WalletAccount(window.near);
 
   // Getting the Account ID. If unauthorized yet, it's just empty string.
   window.accountId = window.walletAccount.getAccountId();
@@ -286,8 +286,8 @@ beforeAll(async function () {
   if (window.testSettings === undefined) {
     window.testSettings = {};
   }
-  near = await nearApi.dev.connect(testSettings);
-  accountId = testSettings.accountId ? testSettings.accountId : nearApi.dev.myAccountId;
+  near = await nearAPI.dev.connect(testSettings);
+  accountId = testSettings.accountId ? testSettings.accountId : nearAPI.dev.myAccountId;
   const contractName = testSettings.contractName ?
     testSettings.contractName :
     (new URL(window.location.href)).searchParams.get("contractName");

--- a/docs/roles/developer/connecting.md
+++ b/docs/roles/developer/connecting.md
@@ -8,7 +8,6 @@ Working with the NEAR network is currently possible under 5 deployment scenarios
 
 - MainNet
 - TestNet
-- DevNet
 - BetaNet
 - LocalNet
 
@@ -35,23 +34,6 @@ The flag for this in near-shell is 'development'
 ### State Management
 
 We make every attempt to maintain the integrity of network state across updates, but this is still a volitile network that receives heavy testing.
-
-## DevNet
-
-DevNet is intended for developers who want to work with or test the latest (`master` branch) features of the NEAR platform.
-
-Releases happen daily at 0:00 UTC.
-
-The flag for this in near-shell is 'devnet'
-
-### State Management
-
-<blockquote class="warning">
-<strong>heads up</strong><br><br>
-
-The state of the network is **not preserved** across updates since breaking changes are likely.
-
-</blockquote>
 
 ## BetaNet
 

--- a/docs/roles/integrator/faq.md
+++ b/docs/roles/integrator/faq.md
@@ -143,10 +143,6 @@ See `nearcore/scripts/nodelib.py` for different examples of configuration.
 - BetaNet
   - https://explorer.betanet.near.org
   - https://rpc.betanet.near.org/status
-- DevNet
-  - https://explorer.devnet.near.org
-  - https://rpc.devnet.near.org/status
-
 
 ### How old can the referenced block hash be before it's invalid?
 
@@ -154,7 +150,7 @@ There is a genesis parameter which can be discovered for any network using:
 
 ```sh
 http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare method=EXPERIMENTAL_genesis_config
-# in the line above, testnet may be replaced with mainnet, betanet or devnet
+# in the line above, testnet may be replaced with mainnet or betanet
 ```
 
 It's `86400` blocks or `~24` hours: https://github.com/nearprotocol/nearcore/blob/master/neard/res/mainnet_genesis.json#L212

--- a/docs/tutorials/near-studio/near-wallet-integration.md
+++ b/docs/tutorials/near-studio/near-wallet-integration.md
@@ -56,7 +56,7 @@ yarn dev
 
 ```js
 (function() {
-  const CONTRACT_NAME = 'near-hello-devnet'; /* TODO: fill this in! */
+  const CONTRACT_NAME = 'near-hello-testnet'; /* TODO: fill this in! */
   const DEFAULT_ENV = 'development';
 
   function getConfig(env) {
@@ -70,14 +70,6 @@ yarn dev
         contractName: CONTRACT_NAME,
         walletUrl: 'https://wallet.testnet.near.org',
         helperUrl: 'https://helper.testnet.near.org',
-      };
-    case 'devnet':
-      return {
-        networkId: 'devnet',
-        nodeUrl: 'https://rpc.devnet.near.org',
-        contractName: CONTRACT_NAME,
-        walletUrl: 'https://wallet.devnet.near.org',
-        helperUrl: 'https://helper.devnet.near.org',
       };
     case 'betanet':
       return {
@@ -184,7 +176,7 @@ export function whoSaidHi(): string | null {
 
 Note that:
 - `initContract()` kicks off the loading of the app
-- `nearApi.connect()` is how we connect to the NEAR blockchain
+- `nearAPI.connect()` is how we connect to the NEAR blockchain
 - `BrowserLocalStorageKeyStore` is what we use to store keys (in your LocalStorage)
 - `viewMethods` and `changeMethods` are the smart contract methods where `viewMethods` do not modify the state of the blockchain and `changeMethods` do
 
@@ -193,12 +185,12 @@ Note that:
 async function initContract() {
   console.log('nearConfig', nearConfig);
 
-  // Initializing connection to the NEAR DevNet.
-  window.near = await nearApi.connect(Object.assign({ deps: { keyStore: new nearApi.keyStores.BrowserLocalStorageKeyStore() } }, nearConfig));
+  // Initializing connection to the NEAR testnet
+  window.near = await nearAPI.connect(Object.assign({ deps: { keyStore: new nearAPI.keyStores.BrowserLocalStorageKeyStore() } }, nearConfig));
 
-  // Initializing Wallet based Account. It can work with NEAR DevNet wallet that
+  // Initializing Wallet based Account. It can work with NEAR testnet wallet that
   // is hosted at https://wallet.testnet.near.org
-  window.walletAccount = new nearApi.WalletAccount(window.near);
+  window.walletAccount = new nearAPI.WalletAccount(window.near);
 
   // Getting the Account ID. If unauthorized yet, it's just empty string.
   window.accountId = window.walletAccount.getAccountId();

--- a/docs/validator/maintenance.md
+++ b/docs/validator/maintenance.md
@@ -6,7 +6,7 @@ sidebar_label: Node Maintenance
 
 ## Updating a Validator Node
 
-As a decentralized network, every update to NEAR Protocol needs some coordination between end users, platforms, developers and validators. [`nearup`](https://github.com/near/nearup) provides scripts to launch NEAR Protocol `TestNet`, `BetaNet` and `DevNet` nodes. Unless it is executed with the switch `--binary-path`, `nearup` will automatically update the local binaries if NEAR's boot nodes fork the network and change the genesis checksum.
+As a decentralized network, every update to NEAR Protocol needs some coordination between end users, platforms, developers and validators. [`nearup`](https://github.com/near/nearup) provides scripts to launch NEAR Protocol `TestNet` and `BetaNet` nodes. Unless it is executed with the switch `--binary-path`, `nearup` will automatically update the local binaries if NEAR's boot nodes fork the network and change the genesis checksum.
 
 For security-critical applications and for validators, `nearup` can run a locally compiled binary of [`nearcore`](https://github.com/nearprotocol/nearcore), but such updates have to be done manually. Since validators are responsible for creating new blocks, coordination in this process is necessary to avoid any network stall.
 
@@ -26,7 +26,6 @@ NEAR's team will be mostly active on Github, and with limited participation on D
 ## Planned Updates
 
 NEAR merges node updates for [`nearcore`](https://github.com/nearprotocol/nearcore) as follows:
-- `DevNet` on a daily basis, to `master` branch
 - `BetaNet` every Wednesday at 00:00 UTC, merging selected `master` features to `beta` branch
 - `TestNet` is not yet subject to planned releases. The official branch is `stable`
 - `MainNet` is not yet subject to planned releases


### PR DESCRIPTION
`DevNet` has been terminated and docs has been purged of its existence. In some cases replacing it with `testnet` was appropriate and testing was performed.