### PR TITLE
remove "Rust" from testing rust contracts sidebar and label

### DIFF
--- a/docs/roles/developer/contracts/testing.md
+++ b/docs/roles/developer/contracts/testing.md
@@ -1,7 +1,7 @@
 ---
-id: test-rust-contracts
-title: Testing Rust contracts
-sidebar_label: Test Rust contracts
+id: test-contracts
+title: Testing contracts
+sidebar_label: Testing contracts
 ---
 
 There are a couple of ways to test Rust smart contracts in NEAR.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -81,7 +81,7 @@
         "type": "subcategory",
         "label": "Testing Contracts",
         "ids": [
-          "roles/developer/contracts/test-rust-contracts"
+          "roles/developer/contracts/test-contracts"
         ]
       },
       {


### PR DESCRIPTION
Simple sidebar labelling change since our tests explain both AS and Rust contracts.