### PR TITLE
[feat] token custody

### DIFF
--- a/docs/code-patterns/arrays.md
+++ b/docs/code-patterns/arrays.md
@@ -1,7 +1,0 @@
----
-id: arrays
-title: Arrays
-sidebar_label: Arrays
----
-
-#### Test

--- a/docs/code-patterns/token-issuance.md
+++ b/docs/code-patterns/token-issuance.md
@@ -1,7 +1,0 @@
----
-id: token-issuance
-title: Token Issuance
-sidebar_label: Token Issuance
----
-
-#### Test

--- a/docs/code-patterns/token-storage.md
+++ b/docs/code-patterns/token-storage.md
@@ -1,7 +1,0 @@
----
-id: token-storage
-title: Token Storage
-sidebar_label: Token Storage
----
-
-#### Test

--- a/docs/code-patterns/token-transfer.md
+++ b/docs/code-patterns/token-transfer.md
@@ -1,7 +1,0 @@
----
-id: token-transfer
-title: Token Transfer
-sidebar_label: Token Transfer
----
-
-#### Test

--- a/docs/tokens/hahaha.md
+++ b/docs/tokens/hahaha.md
@@ -1,6 +1,0 @@
----
-id: token-custody-haha
-title: Token Custody hahaOptions
-sidebar_label: haha
----
-har har

--- a/docs/tokens/hahaha.md
+++ b/docs/tokens/hahaha.md
@@ -1,0 +1,6 @@
+---
+id: token-custody-haha
+title: Token Custody hahaOptions
+sidebar_label: haha
+---
+har har

--- a/docs/tokens/token-custody.md
+++ b/docs/tokens/token-custody.md
@@ -12,7 +12,9 @@ There are several options available to manage your NEAR and NEAR-based assets. T
   - The [NEAR Web Wallet](http://wallet.near.org) is the easiest way to get started on NEAR. If you have an allocation of NEAR tokens, ask your facilitator (CoinList or the NEAR Foundation) to send you a NEAR Drop and follow [this guide](https://docs.google.com/document/d/13b3K_9f0YZudFrEAmagM4RcesK3DFxPBE5DswJ37Das). 
   - NEAR Wallet also supports Ledger hardware devices for improved security.
 
-- ### Mobile Wallets
+## Mobile Wallets
+
+- ### Trust Wallet
 
   - [Trust Wallet](https://trustwallet.com/) is a very popular, non-custodial, wallet available on iOS and Android.
 
@@ -21,9 +23,9 @@ There are several options available to manage your NEAR and NEAR-based assets. T
   - ### Ledger via CLI 
       - For users with advanced security requirements and the need for flexibility (developers and validators), we highly recommend using our command line interface [(NEAR-CLI)](https://docs.near.org/docs/development/near-cli) with a Ledger hardware device.
       - This [community-authored guide](https://medium.com/@bonsfi/how-to-use-ledger-with-near-cli-648d5d990517) walks through several common commands
-
-  - ### Ledger Live
-      - You can install the NEAR Ledger app in [Ledger Live](https://www.ledger.com/ledger-live) by:
+      
+      **Installing the NEAR Ledger App**
+      - You can install the NEAR Ledger app using [Ledger Live](https://www.ledger.com/ledger-live) by:
         1) Open Ledger Live and install any available firmware updates
         2) Go to `Settings`
         3) Under `Experimental Features` ensure `Developer Mode` is switched on
@@ -31,6 +33,6 @@ There are several options available to manage your NEAR and NEAR-based assets. T
         5) Follow instructions to install the NEAR app on your device
 
 ## Custodians (Recommended for institutional users)
-  - ### Fiona
-    - [Fiona](https://finoa.io/) is the first qualified custodian to offer NEAR asset custody
-    - Check with [Fiona](https://finoa.io/contact) to see if you are eligible
+  - ### Finoa
+    - [Finoa](https://finoa.io/) is the first qualified custodian to offer NEAR asset custody
+    - Check with [Finoa](https://finoa.io/contact) to see if you are eligible

--- a/docs/tokens/token-custody.md
+++ b/docs/tokens/token-custody.md
@@ -1,0 +1,21 @@
+---
+id: token-custody
+title: Token Custody Options
+sidebar_label: toke
+---
+There are several options available to manage your NEAR and NEAR-based assets. This list is regularly updated as more products and providers offer NEAR support.
+
+## Web Wallets
+
+- ### NEAR Wallet
+
+  - The [NEAR Web Wallet](http://wallet.near.org) is the easiest way to get started on NEAR. If you have an allocation of NEAR tokens, ask your facilitator (CoinList, the NEAR Foundation) to send you a NEAR Drop, and follow [this guide](https://docs.google.com/document/d/13b3K_9f0YZudFrEAmagM4RcesK3DFxPBE5DswJ37Das). The NEAR Wallet also supports Ledger hardware devices for improved security.
+
+- ### Mobile Wallets
+
+  - [Trust Wallet](https://trustwallet.com/) is a very popular, non-custodial wallet available on iOS and Android.
+
+## CLI (Recommended for developers and validators)
+  - ### Ledger via CLI 
+      - For users with advanced security requirements and the need for flexibility (developers and validators), we highly recommend using our Command Line Interface, near-cli with a Ledger hardware device.
+      - This community-authored guide walks through several common commands:  https://medium.com/@bonsfi/how-to-use-ledger-with-near-cli-648d5d990517 You can install the NEAR Ledger app in Ledger Live with these steps: -

--- a/docs/tokens/token-custody.md
+++ b/docs/tokens/token-custody.md
@@ -1,7 +1,7 @@
 ---
 id: token-custody
 title: Token Custody Options
-sidebar_label: toke
+sidebar_label: Token Custody
 ---
 There are several options available to manage your NEAR and NEAR-based assets. This list is regularly updated as more products and providers offer NEAR support.
 
@@ -9,13 +9,28 @@ There are several options available to manage your NEAR and NEAR-based assets. T
 
 - ### NEAR Wallet
 
-  - The [NEAR Web Wallet](http://wallet.near.org) is the easiest way to get started on NEAR. If you have an allocation of NEAR tokens, ask your facilitator (CoinList, the NEAR Foundation) to send you a NEAR Drop, and follow [this guide](https://docs.google.com/document/d/13b3K_9f0YZudFrEAmagM4RcesK3DFxPBE5DswJ37Das). The NEAR Wallet also supports Ledger hardware devices for improved security.
+  - The [NEAR Web Wallet](http://wallet.near.org) is the easiest way to get started on NEAR. If you have an allocation of NEAR tokens, ask your facilitator (CoinList or the NEAR Foundation) to send you a NEAR Drop and follow [this guide](https://docs.google.com/document/d/13b3K_9f0YZudFrEAmagM4RcesK3DFxPBE5DswJ37Das). 
+  - NEAR Wallet also supports Ledger hardware devices for improved security.
 
 - ### Mobile Wallets
 
-  - [Trust Wallet](https://trustwallet.com/) is a very popular, non-custodial wallet available on iOS and Android.
+  - [Trust Wallet](https://trustwallet.com/) is a very popular, non-custodial, wallet available on iOS and Android.
 
 ## CLI (Recommended for developers and validators)
+
   - ### Ledger via CLI 
-      - For users with advanced security requirements and the need for flexibility (developers and validators), we highly recommend using our Command Line Interface, near-cli with a Ledger hardware device.
-      - This community-authored guide walks through several common commands:  https://medium.com/@bonsfi/how-to-use-ledger-with-near-cli-648d5d990517 You can install the NEAR Ledger app in Ledger Live with these steps: -
+      - For users with advanced security requirements and the need for flexibility (developers and validators), we highly recommend using our command line interface [(NEAR-CLI)](https://docs.near.org/docs/development/near-cli) with a Ledger hardware device.
+      - This [community-authored guide](https://medium.com/@bonsfi/how-to-use-ledger-with-near-cli-648d5d990517) walks through several common commands
+
+  - ### Ledger Live
+      - You can install the NEAR Ledger app in [Ledger Live](https://www.ledger.com/ledger-live) by:
+        1) Open Ledger Live and install any available firmware updates
+        2) Go to `Settings`
+        3) Under `Experimental Features` ensure `Developer Mode` is switched on
+        4) Return to the `Manager` tab and search for NEAR
+        5) Follow instructions to install the NEAR app on your device
+
+## Custodians (Recommended for institutional users)
+  - ### Fiona
+    - [Fiona](https://finoa.io/) is the first qualified custodian to offer NEAR asset custody
+    - Check with [Fiona](https://finoa.io/contact) to see if you are eligible

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -134,10 +134,7 @@
     ]
   },
   "tokens": {
-    "Token Basics": ["tokens/token-custody"],
-    "Haha":[
-      "tokens/token-custody-haha"
-    ]
+    "Token Basics": ["tokens/token-custody"]
   },
   "contribute": {
     "Quickstart": [

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -133,6 +133,11 @@
       "roles/integrator/faq"
     ]
   },
+  "tokens": {
+    "Near Wallet": [
+      "quick-start/near-wallet"
+    ]
+  },
   "contribute": {
     "Quickstart": [
       "contribution/contribution-overview"

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -134,8 +134,9 @@
     ]
   },
   "tokens": {
-    "Near Wallet": [
-      "quick-start/near-wallet"
+    "Token Basics": ["tokens/token-custody"],
+    "Haha":[
+      "tokens/token-custody-haha"
     ]
   },
   "contribute": {

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -13,6 +13,7 @@ const siteConfig = {
     { doc: "roles/developer/quickstart", label: "develop" },
     { doc: "validator/staking-overview", label: "validate" },
     { doc: "roles/integrator/quickstart", label: "integrate" },
+    { doc: "tokens/token-custody", label: "tokens"},
     { doc: "contribution/contribution-overview", label: "contribute" },
     { doc: "api/quickstart", label: "API" },
     { search: true },


### PR DESCRIPTION
- Added `tokens` to main nav bar
- Added Token Custody Options markdown and set it as the temporary landing page for `tokens` 
- Future landing page for `tokens` will have basic information about NEAR tokens as well as links to issuing tokens, transferring tokens, token-custody, creating accounts/wallet, etc.