### PR TITLE
Add clang dependency for building from source

### DIFF
--- a/docs/contribution/nearcore.md
+++ b/docs/contribution/nearcore.md
@@ -15,6 +15,14 @@ rustup component add clippy-preview
 rustup default nightly
 ```
 
+Install development dependencies (OS-dependent):
+
+_Ubuntu_:
+
+```bash
+sudo apt install make clang
+```
+
 **2. Clone repository**
 
 We would need to copy the entire repository:


### PR DESCRIPTION
This comes after a request from a community member: https://discordapp.com/channels/490367152054992913/710764455398735906/748640450939715706

I am only familiar with building on Ubuntu, but if others want to add any additional dependencies for building on Mac or Windows, then feel free add them.

Note: I tested this with a fresh Ubuntu image using `docker run -it ubuntu` and it worked, though there are still some assumed dependencies (e.g. `curl` and `git`), I'm not sure where we want to draw the line in terms of what we assume people have vs what we include install commands for.