### PR TITLE
fix seat price math and tune number of seats wording

### DIFF
--- a/docs/validator/economics.md
+++ b/docs/validator/economics.md
@@ -129,10 +129,10 @@ Let's say you observe a set of proposals (and rollovers from previous epoch):
 | V2        | 500,000              | 24      |
 | V3        | 300,000              | 14      |
 | V4        | 300,000              | 14      |
-| ---       | seat price is 20,500 | ---     |
+| ---       | seat price is 21,200 | ---     |
 | V5        | 20,000               | 0       |
 
-The *seat price* given this proposals is determined by finding such integer number that if you divide each validator's stake with rounding down (e.g. V5 20,000 / 20,500 with rounding down will be 0) - you will get required number of seats. This determines who will get their seat(s) and who's funds will be returned back to them.
+The *seat price* given this proposals is determined by finding such integer number that if you divide each validator's stake by seat price with rounding down (e.g. V5 20,000 / 21,200 with rounding down will be 0) - you will get assigned number of seats. This determines who will get their seat(s) and who's funds will be returned back to them.
 
 The *seat price* for current epoch can be obtained by dividing the total at stake by the number of seats, for example at 400 million $NEAR at stake and 100 total seats, the *seat price* will be 4 million.
 


### PR DESCRIPTION
Initially spotted in https://near.org/blog/near-protocol-economics/
and then in this document. I think seat price is 21,200.

      $ bc
      1000000 + 500000 + 300000 + 300000 + 20000
      2120000
      48 + 24 + 14 + 14
      100
      2120000 / 100
      21200

Also I found wording confusing, as when one thinks about division,
there is dividend and divisor and sentence was missing explanation
what is that divisor.

With another part of the same sentene I've changed

> you will get required number of seats

to

> you will get assigned number of seats

as in my mind required number of seats is defined by the blockchain
configuration and assigned would be just in that epoch, just for that
validator.