### PR TITLE
updated links to near-sdk-as

### DIFF
--- a/docs/api/quickstart.md
+++ b/docs/api/quickstart.md
@@ -34,7 +34,7 @@ Just let us know if you need help with a note via [email](mailto:hello@near.org)
 ### AssemblyScript (`near-sdk-as`)
 - API documentation is [here](https://near.github.io/near-sdk-as)
 - examples are [here](https://github.com/near-examples)
-- tests are [here](https://github.com/near/near-sdk-as/tree/master/assembly/__tests__)
+- tests are [here](https://github.com/near/near-sdk-as/tree/master/sdk/assembly/__tests__)
 
 ## Developing Applications
 

--- a/docs/concepts/storage.md
+++ b/docs/concepts/storage.md
@@ -54,7 +54,7 @@ A [non-fungible token](https://github.com/nearprotocol/NEPs/pull/4) is unique, w
 
 If such an NFT is used to track **1 million** tokens, how much storage will be required for the token-ID-to-owner mapping? And how many tokens will need to be staked for that storage?
 
-Using [this basic AssemblyScript implementation](https://github.com/near-examples/NFT/tree/master/contracts/assemblyscript/nep4-basic) as inspiration, let's calculate the storage needs when using a [`PersistentMap`](https://near.github.io/near-sdk-as/classes/_assembly_sdk_collections_persistentmap_.persistentmap.html) from `near-sdk-as`. While its specific implementation may change in the future, at the time of writing `near-sdk-as` stored data as UTF-8 strings. We'll assume this below.
+Using [this basic AssemblyScript implementation](https://github.com/near-examples/NFT/tree/master/contracts/assemblyscript/nep4-basic) as inspiration, let's calculate the storage needs when using a [`PersistentMap`](https://near.github.io/near-sdk-as/classes/_sdk_core_assembly_collections_persistentmap_.persistentmap.html) from `near-sdk-as`. While its specific implementation may change in the future, at the time of writing `near-sdk-as` stored data as UTF-8 strings. We'll assume this below.
 
 Here's our `PersistentMap`:
 

--- a/docs/hackathon/startup-guide.md
+++ b/docs/hackathon/startup-guide.md
@@ -134,7 +134,7 @@ The call to `loadContract` is actually making an object with your functions that
 
 ### 3. How do I save data to the blockchain?
 
-You can use [Storage](https://near.github.io/near-sdk-as/classes/_assembly_sdk_storage_.storage-1.html) or collections (described below). These are pretty raw in terms of documentation because they are under heavy development.
+You can use [Storage](https://near.github.io/near-sdk-as/modules/_sdk_core_assembly_storage_.html) or collections (described below). These are pretty raw in terms of documentation because they are under heavy development.
 
 **For most cases, you can use collections.** For instance, if you want to use a map for saving data to storage you can use `PersistentMap` to create a persistent map.
 Please note that the data stored in this map will be persistent, which means that your application will have to pay rent for whatever data stored there. If you do not want to persist data in storage, it's better to use `Map` instead which will mean your data will only be available in memory during the life of the function call.

--- a/docs/roles/developer/contracts/assemblyscript.md
+++ b/docs/roles/developer/contracts/assemblyscript.md
@@ -75,7 +75,7 @@ To keep things organized, contracts can use one or more data objects which are c
 
 #### Imports
 
-All contracts and models must explicitly import features of the NEAR runtime they intend to use.  Not all of these features are used all of the time of course.
+All contracts and models must explicitly import features of the NEAR they intend to use.  Not all of these features are used all of the time of course.
 
 ```ts
 import {
@@ -322,7 +322,7 @@ class Storage {
 }
 ```
 
-See the [`Storage` class implementation here](https://github.com/near/near-sdk-as/blob/master/assembly/sdk/storage.ts) for details
+See the [`Storage` class implementation here](https://github.com/near/near-sdk-as/blob/master/sdk-core/assembly/storage.ts) for details
 
 
 ### Collections
@@ -430,7 +430,7 @@ class PersistentVector<T> {             // referred to as "pv" below
 }
 ```
 
-Sample code using `PersistentVector` is in the [tests for `near-sdk-as`](https://github.com/near/near-sdk-as/blob/master/assembly/__tests__/runtime/main.ts)
+Sample code using `PersistentVector` is in the [tests for `near-sdk-as`](https://github.com/near/near-sdk-as/blob/master/sdk/assembly/__tests__/main.ts)
 
 
 #### PersistentDeque

--- a/docs/roles/developer/contracts/assemblyscript.md
+++ b/docs/roles/developer/contracts/assemblyscript.md
@@ -33,7 +33,7 @@ For rich examples of AssemblyScript written for the NEAR platform check out:
 - [examples](http://near.dev): sample applications you can explore online with gitpod IDE.
 - [CryptoCorgis*](https://github.com/nearprotocol/corgis): a playful take on NFTs (non-fungible tokens)
 - [NEAR Chess](https://github.com/nearprotocol/near-chess/tree/master/assembly): a NEAR implementation of [chessboard.js](https://chessboardjs.com/)
-- [`near-sdk-as`](https://github.com/near/near-sdk-as/tree/master/assembly): our library for writing near smart contracts
+- [`near-sdk-as`](https://github.com/near/near-sdk-as/tree/master/sdk/assembly): our library for writing near smart contracts
 
 *CryptoCorgis is currently a private repo available here: `github.com/near/corgis`
 
@@ -149,7 +149,7 @@ The most sophisticated models currently available as open source are:
 
 - models for [Meta NEAR](https://github.com/nearprotocol/metanear-src/blob/master/assembly/model.ts)
 - models for [NEAR Place](https://github.com/nearprotocol/near-place/blob/master/assembly/model.ts)
-- models for [`near-sdk-as` tests](https://github.com/near/near-sdk-as/blob/master/assembly/__tests__/model.ts)
+- models for [`near-sdk-as` tests](https://github.com/near/near-sdk-as/blob/master/sdk/assembly/__tests__/model.ts)
 - models for [NEAR Chess](https://github.com/nearprotocol/near-chess/blob/master/assembly/model.ts)
 
 *Note that some of the projects listed above may need to have some updates applied before a successful deployment is possible*
@@ -378,7 +378,7 @@ class PersistentMap<K, V> {
 }
 ```
 
-Sample code using `PersistentMap` is in the [tests for `near-sdk-as`](https://github.com/near/near-sdk-as/blob/master/assembly/__tests__/runtime/main.ts)
+Sample code using `PersistentMap` is in the [tests for `near-sdk-as`](https://github.com/near/near-sdk-as/blob/master/sdk/assembly/__tests__/main.ts)
 
 
 #### PersistentVector
@@ -480,7 +480,7 @@ class PersistentDeque<T> {            // referred to as "pdq" below
 }
 ```
 
-Sample code using `PersistentDeque` is in the [tests for `near-sdk-as`](https://github.com/near/near-sdk-as/blob/master/assembly/__tests__/runtime/main.ts)
+Sample code using `PersistentDeque` is in the [tests for `near-sdk-as`](https://github.com/near/near-sdk-as/blob/master/sdk/assembly/__tests__/main.ts)
 
 <blockquote class="info">
 <strong>did you know?</strong><br><br>

--- a/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
+++ b/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
@@ -330,7 +330,7 @@ export class CalculatorApi {
 
 ```
 
-*(For more info on making cross-contract calls using `ContractPromise`, check out [ContractPromise](https://near.github.io/near-sdk-as/classes/_assembly_sdk_contract_.contractpromise.html) and [ContractPromiseResult](https://near.github.io/near-sdk-as/classes/_assembly_sdk_contract_.contractpromiseresult.html)*
+*(For more info on making cross-contract calls using `ContractPromise`, check out [ContractPromise](https://near.github.io/near-sdk-as/classes/_sdk_core_assembly_contract_.contractpromise.html) and [ContractPromiseResult](https://near.github.io/near-sdk-as/classes/_sdk_core_assembly_contract_.contractpromiseresult.html)*
 
 <blockquote class="warning">
 <strong>heads up</strong><br><br>

--- a/docs/tutorials/near-studio/token.md
+++ b/docs/tutorials/near-studio/token.md
@@ -77,7 +77,7 @@ export function init(initialOwner: string): void {
 }
 ```
 
-In example above we have a `storage` object that is accessible by this contract to store data. It's just a key-value storage.  You can see the full implementation of the `Storage` class in the [`near-sdk-as` source here](https://github.com/near/near-sdk-as/blob/master/assembly/sdk/storage.ts).
+In example above we have a `storage` object that is accessible by this contract to store data. It's just a key-value storage.  You can see the full implementation of the `Storage` class in the [`near-sdk-as` source here](https://github.com/near/near-sdk-as/blob/master/sdk-core/assembly/storage.ts).
 
 Now that it's initialized, we can check the balance of users.
 
@@ -115,7 +115,7 @@ export function transfer(to: string, tokens: u64): boolean {
 
 Note, this is not a view function and it can fail, so we need to return `boolean` to indicate if it was successful. We first check the balance of `context.sender`, which is the user that executed given transaction. If there is not enough money on the balance, we return `false`. Otherwise, subtract `value` from the balance of sender and increment balance of `to`.
 
-You can see the full implementation of the `Context` class in the[ `near-sdk-as` source here](https://github.com/near/near-sdk-as/blob/master/assembly/sdk/contract.ts).
+You can see the full implementation of the `Context` class in the[ `near-sdk-as` source here](https://github.com/near/near-sdk-as/blob/master/sdk-core/assembly/contract.ts).
 
 You'll notice that we've also implemented `transferFrom`, `approve` and `allowance` in the sample.
 

--- a/docs/tutorials/zero-to-hero.md
+++ b/docs/tutorials/zero-to-hero.md
@@ -87,7 +87,7 @@ Now that we logged in with near, let's implement a public API endpoint to provid
 
 The first thing that our Oracle Contract must be able to do is read from and write to the blockchain. This way our contract can save external data onto the blockchain for other contracts to interact with.
 
-Navigate to our API [storage docs](https://near.github.io/near-sdk-as/classes/_assembly_sdk_storage_.storage-1.html) to review the `setString` and `getString` functions. In later steps we'll show you how to handle more complicated data types.
+Navigate to our API [storage docs](https://near.github.io/near-sdk-as/modules/_sdk_core_assembly_storage_.html) to review the `setString` and `getString` functions. In later steps we'll show you how to handle more complicated data types.
 
 Data can be stored in a simple key-value store. To save a string, we only need to pass a key with the string we want to save. For now let's use the string `"response"` as our key.
 


### PR DESCRIPTION
`near-sdk-as` v2.0.0 was published and links in docs needed updating. This PR updates all broken links associated with this new release.