### PR TITLE
removed link to wallet

### DIFF
--- a/docs/local-setup/create-account.md
+++ b/docs/local-setup/create-account.md
@@ -4,6 +4,10 @@ title: Creating a NEAR Account in Testnet
 sidebar_label: Create Your Account
 ---
 
+## Try NEAR Wallet
+
+https://wallet.testnet.near.org
+
 Before you get started with NEAR, the first thing that you want to do is to set up a NEAR account on Testnet. This account will also be seeded with a balance so that you can use those funds to deploy your contracts, access applications, and stake tokens.
 
 Either read-on to learn more about the wallet or jump to [set up your wallet](#set-up-your-wallet).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -3,7 +3,6 @@
     "Quickstart": ["quick-start/new-to-near", "overview/basics-orientation"],
     "Getting Started": [
       "local-setup/create-account",
-      "quick-start/near-wallet",
       "quick-start/near-explorer",
       "development/near-cli",
       "quick-start/github"


### PR DESCRIPTION
@thisisjoshford I removed the link to the wallet page in the getting started section since the AccountID walk-through already covers how to use the wallet.

However, I left the page that simply links to the [NEAR wallet](https://docs.near.org/docs/quick-start/near-wallet) so that if people look specifically for the wallet in the search bar, they can still find it. 