### PR TITLE
Specify gas to call deposit_and_stake

### DIFF
--- a/docs/validator/delegation.md
+++ b/docs/validator/delegation.md
@@ -115,7 +115,7 @@ Where the `<LOCKUP_ID>` is `meerkat.stakewars.testnet` and the resulting balance
 
 2. To stake the balance, use the call method `deposit_and_stake`:
 ```
-near call <LOCKUP_ID> deposit_and_stake '{"amount": "<AMOUNT>"}' --accountId <OWNER_ID>
+near call <LOCKUP_ID> deposit_and_stake '{"amount": "<AMOUNT>"}' --accountId <OWNER_ID> --gas=125000000000000
 ```
 You should expect a result like:
 ```


### PR DESCRIPTION
Per the [lockup core-contract documentation](https://github.com/near/core-contracts/tree/master/lockup#deposit-and-stake-to-the-staking-pool) it is required 125Tg or 5 * BASE_GAS. Currently `near-cli` is using smaller gas by default so calling this function fails with `GasExceeded [Error]: Exceeded the prepaid gas`.