### PR TITLE
for NEAR CLI add section about package manager and nvm

### DIFF
--- a/docs/development/near-cli.md
+++ b/docs/development/near-cli.md
@@ -71,8 +71,8 @@ _Click on a command for more information and examples._
 
 #### Mac and Linux
 
-1. Install `npm` [[ click here ]](https://www.npmjs.com/get-npm)
-2. Install `NodeJS` [[ click here ]](https://nodejs.org/en/download)
+1. Install `npm` It's recommended to use a package manager like `nvm` as sometimes there are issues using Ledger due to how OS X handles node packages related to USB devices. [[ click here ]](https://nodejs.org/en/download/package-manager/)
+2. Ensure you have installed Node version 12 or above.
 3. Install `near-cli` globally by running:
 
 ```bash

--- a/docs/development/near-cli.md
+++ b/docs/development/near-cli.md
@@ -71,7 +71,7 @@ _Click on a command for more information and examples._
 
 #### Mac and Linux
 
-1. Install `npm` It's recommended to use a package manager like `nvm` as sometimes there are issues using Ledger due to how OS X handles node packages related to USB devices. [[ click here ]](https://nodejs.org/en/download/package-manager/)
+1. Install `npm` and `node` using a package manager like `nvm` as sometimes there are issues using Ledger due to how OS X handles node packages related to USB devices. [[ click here ]](https://nodejs.org/en/download/package-manager/)
 2. Ensure you have installed Node version 12 or above.
 3. Install `near-cli` globally by running:
 


### PR DESCRIPTION
As we have on the homepage, https://near.org, we should mention that for Linux/Mac users they should use a package manager.
I have not heard from folks that Windows needs a package manager. If we hear that feedback, we can modify the Windows section as well.