### PR TITLE
Fix description of allowance in function call key

### DIFF
--- a/docs/concepts/account.md
+++ b/docs/concepts/account.md
@@ -109,7 +109,7 @@ A `FunctionCall` key is unique as it only has permission to call a smart contrac
 1) `allowance` - the amount of Ⓝ the key is allowed to spend on gas fees _(optional - default: `null`)_
 2) `receiver_id` - contract the key is allowed to call methods on _(required)_
 3) `method_names` - contract methods the key is allowed to call _(optional)_
-
+**Note:** If `allowance` is omitted the default will be `null` and key will only be allowed to call view methods. Allowance can not be added after key is created.
 > **Note:** If no specific method names are specified, all methods may be called.
 
 The easiest way to create a `FunctionCall` key with your dApp is to prompt users to sign in using [NEAR Wallet](https://wallet.testnet.near.org/) via `near-api-js`'s [`WalletConnection`](https://github.com/near/near-api-js/blob/0aefdb01a151f7361463f3ff65c77dbfeee83200/lib/wallet-account.js#L13-L139). This prompts users to authorize access and upon approval a `FunctionCall` key is created. This key is only allowed to call methods on the contract that redirected the user to NEAR Wallet with a default allowance of 0.25 Ⓝ to cover gas costs for transactions. As non-monetary transactions are performed with this key, you will notice the allowance decreases and once 0.25 Ⓝ is burnt a new key will need to be created. If a request is made to transfer _ANY_ amount of tokens with a `FunctionCall` key, the user will be redirected back to wallet to authorize this transaction. You can see this functionality in action by trying out [NEAR Guestbook](https://near-examples.github.io/guest-book/).

--- a/docs/concepts/account.md
+++ b/docs/concepts/account.md
@@ -106,7 +106,7 @@ See our [action specifications](https://nomicon.io/RuntimeSpec/Actions.html) sec
 
 A `FunctionCall` key is unique as it only has permission to call a smart contract's method(s) that _do not_ attach Ⓝ as a deposit (i.e. payable functions). These keys have the following three attributes:
 
-1) `allowance` - the amount of Ⓝ the key is allowed to spend on gas fees _(required)_
+1) `allowance` - the amount of Ⓝ the key is allowed to spend on gas fees _(optional - default: `null`)_
 2) `receiver_id` - contract the key is allowed to call methods on _(required)_
 3) `method_names` - contract methods the key is allowed to call _(optional)_
 

--- a/docs/concepts/account.md
+++ b/docs/concepts/account.md
@@ -106,7 +106,7 @@ See our [action specifications](https://nomicon.io/RuntimeSpec/Actions.html) sec
 
 A `FunctionCall` key is unique as it only has permission to call a smart contract's method(s) that _do not_ attach Ⓝ as a deposit (i.e. payable functions). These keys have the following three attributes:
 
-1) `allowance` - amount of Ⓝ loaded onto the key to pay for gas fees  _(0.25 default)_
+1) `allowance` - the amount of Ⓝ the key is allowed to spend on gas fees _(required)_
 2) `receiver_id` - contract the key is allowed to call methods on _(required)_
 3) `method_names` - contract methods the key is allowed to call _(optional)_
 


### PR DESCRIPTION
### Description

Find this issue when reviewing the document: https://medium.com/nearprotocol/an-introduction-to-near-accounts-f96cb84ef091

For `allowance` of function call key:

1. 0.25 default is not right as we discussed in https://github.com/near/docs/issues/660 I changed it to "required" but seems not that accurate as well, since the default value should be "null" which allows calling view methods only. 
2. the description of `allowance` seems not accurate for **amount of Ⓝ loaded onto the key**