### PR TITLE
fix CI by whitelisting GH edit button

### DIFF
--- a/website/linkinator.config.json
+++ b/website/linkinator.config.json
@@ -13,7 +13,8 @@
       "https://rpc.near.org/",
       "http://localhost:5000/css/fonts.css",
       "http://localhost:5000/css/landing-page.css",
-      "http://localhost:5000/css/copy-code-button.css"
+      "http://localhost:5000/css/copy-code-button.css",
+      "https://github.com/near/docs/tree/master/docs"
     ],
     "retry": true
   }


### PR DESCRIPTION
GH edit button (instant PR) on docs needs to be whitelisted for link checker to pass when creating new docs.