### PR TITLE
Fix creating key store from file system in near-api-js quick reference

### DIFF
--- a/docs/api/naj-quick-reference.md
+++ b/docs/api/naj-quick-reference.md
@@ -71,7 +71,8 @@ const homedir = require("os").homedir();
 
 const ACCOUNT_ID = "near-example.testnet";  // NEAR account tied to the keyPair
 const NETWORK_ID = "testnet";
-const KEY_PATH = `/.near-credentials/${NETWORK_ID}/${ACCOUNT_ID}.json`;
+// path to your custom keyPair location (ex. function access key for example account)
+const KEY_PATH = '/.near-credentials/near-example-testnet/get_token_price.json';
 
 const credentials = JSON.parse(fs.readFileSync(homedir + KEY_PATH));
 const keyStore = new keyStores.InMemoryKeyStore();

--- a/docs/api/naj-quick-reference.md
+++ b/docs/api/naj-quick-reference.md
@@ -48,8 +48,9 @@ const keyStore = new keyStores.BrowserLocalStorageKeyStore();
 <!--Using Credentials Directory-->
 
 ```js
-// creates keyStore from credentials directory
-// you should have login the account with NEAR CLI: https://docs.near.org/docs/tools/near-cli#near-login
+// creates a keyStore that searches for keys in .near-credentials
+// requires credentials stored locally by using a NEAR-CLI command: `near login` 
+// https://docs.near.org/docs/tools/near-cli#near-login
 
 const { keyStores } = nearAPI;
 const homedir = require("os").homedir();
@@ -64,11 +65,17 @@ const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
 // creates keyStore from a provided file
 // you will need to pass the location of the .json key pair
 
-const { keyStores, KeyPair } = nearAPI;
-const KEY_PATH = "~/.near-credentials/testnet/example-account.json";
-const credentials = JSON.parse(fs.readFileSync(KEY_PATH));
+const { KeyPair, keyStores } = require("near-api-js");
+const fs = require("fs");
+const homedir = require("os").homedir();
+
+const ACCOUNT_ID = "near-example.testnet";  // NEAR account tied to the keyPair
+const NETWORK_ID = "testnet";
+const KEY_PATH = "/.near-credentials/testnet/near-example.testnet.json";
+
+const credentials = JSON.parse(fs.readFileSync(homedir + KEY_PATH));
 const keyStore = new keyStores.InMemoryKeyStore();
-keyStore.setKey(networkId, appName, KeyPair.fromString(credentials.private_key));
+keyStore.setKey(NETWORK_ID, ACCOUNT_ID, KeyPair.fromString(credentials.private_key));
 ```
 
 <!--Using a private key string-->

--- a/docs/api/naj-quick-reference.md
+++ b/docs/api/naj-quick-reference.md
@@ -71,7 +71,7 @@ const homedir = require("os").homedir();
 
 const ACCOUNT_ID = "near-example.testnet";  // NEAR account tied to the keyPair
 const NETWORK_ID = "testnet";
-const KEY_PATH = "/.near-credentials/testnet/near-example.testnet.json";
+const KEY_PATH = `/.near-credentials/${NETWORK_ID}/${ACCOUNT_ID}.json`;
 
 const credentials = JSON.parse(fs.readFileSync(homedir + KEY_PATH));
 const keyStore = new keyStores.InMemoryKeyStore();

--- a/docs/api/naj-quick-reference.md
+++ b/docs/api/naj-quick-reference.md
@@ -45,15 +45,30 @@ const { keyStores } = nearAPI;
 const keyStore = new keyStores.BrowserLocalStorageKeyStore();
 ```
 
+<!--Using Credentials Directory-->
+
+```js
+// creates keyStore from credentials directory
+// you should have login the account with NEAR CLI: https://docs.near.org/docs/tools/near-cli#near-login
+
+const { keyStores } = nearAPI;
+const homedir = require("os").homedir();
+const CREDENTIALS_DIR = ".near-credentials";
+const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
+const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
+```
+
 <!--Using a File-->
 
 ```js
 // creates keyStore from a provided file
 // you will need to pass the location of the .json key pair
 
-const { keyStores } = nearAPI;
-const KEY_PATH = "~./near-credentials/testnet/example-account.json";
-const keyStore = new keyStores.UnencryptedFileSystemKeyStore(KEY_PATH);
+const { keyStores, KeyPair } = nearAPI;
+const KEY_PATH = "~/.near-credentials/testnet/example-account.json";
+const credentials = JSON.parse(fs.readFileSync(KEY_PATH));
+const keyStore = new keyStores.InMemoryKeyStore();
+keyStore.setKey(networkId, appName, KeyPair.fromString(credentials.private_key));
 ```
 
 <!--Using a private key string-->


### PR DESCRIPTION
### Description

As reported by developers, the [`keyStore` section](https://docs.near.org/docs/api/naj-quick-reference#key-store) in near-api-js quick reference contains mistakes of how to create `keyStore` from file system. 

The examples in cookbook seem to be correct: https://docs.near.org/docs/api/naj-cookbook#create-account

I fixed this with two examples of loading `keyStore` from a file and from the credentials directory. 