### PR TITLE
enhance near create-account details

### DIFF
--- a/docs/concepts/account.md
+++ b/docs/concepts/account.md
@@ -13,21 +13,21 @@ NEAR uses human readable account IDs instead of a public key hash. For a 20-minu
 - `Account ID` consists of `Account ID parts` separated by `.`
 - `Account ID part` consists of lowercase alphanumeric symbols separated by either `_` or `-`.
 
-Account names are similar to a domain names. Anyone can create a top level account (TLA) without separators, e.g. `near`. Only `near` can create `alice.near`. And only `alice.near` can create `app.alice.near` and so on. Note, `near` can NOT create `app.alice.near` directly.
+Account names are similar to a domain names. Anyone can create a top-level account (TLA) without separators, e.g. `near`. Only `near` can create `alice.near`. And only `alice.near` can create `app.alice.near` and so on. Note, `near` can NOT create `app.alice.near` directly.
 
 Regex for a full account ID, without checking for length: `^(([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+$`
 
 ---
 
-## Top Level Accounts
+## Top-level Accounts
 
-Top level account names (TLAs) are very valuable as they provide root of trust and discoverability for companies, applications and users. To allow for fair access to them, the top level account names that are shorter than `MIN_ALLOWED_TOP_LEVEL_ACCOUNT_LENGTH` characters (32 at time of writing) will be auctioned off.
+Top-level account names (TLAs) are very valuable as they provide root of trust and discoverability for companies, applications and users. To allow for fair access to them, the top-level account names that are shorter than `MIN_ALLOWED_TOP_LEVEL_ACCOUNT_LENGTH` characters (32 at time of writing) will be auctioned off.
 
-Specifically, only `REGISTRAR_ACCOUNT_ID` account can create new top level accounts that are shorter than `MIN_ALLOWED_TOP_LEVEL_ACCOUNT_LENGTH` characters. `REGISTRAR_ACCOUNT_ID` implements a standard `Account Naming` interface which allow it to create new accounts.
+Specifically, only `REGISTRAR_ACCOUNT_ID` account can create new top-level accounts that are shorter than `MIN_ALLOWED_TOP_LEVEL_ACCOUNT_LENGTH` characters. `REGISTRAR_ACCOUNT_ID` implements a standard `Account Naming` interface which allow it to create new accounts.
 
 We are not going to deploy the `registrar` auction at launch. Instead we will allow it to be deployed by the Near Foundation at some point in the future.
 
-Currently all `mainnet` accounts use a `near` top level account name (ex `example.near`) and all `testnet` accounts use a `testnet` top level account (ex. `example.testnet`).
+Currently all `mainnet` accounts use a `near` top-level account name (ex `example.near`) and all `testnet` accounts use a `testnet` top-level account (ex. `example.testnet`).
 
 ---
 

--- a/docs/tools/near-cli.md
+++ b/docs/tools/near-cli.md
@@ -509,7 +509,7 @@ near delete-key example-acct.testnet Cxg2wgFYrdLTEkMu6j5D6aEZqTb3kXbmJygS48ZKbo1
 <blockquote class="warning">
 <strong>heads up</strong><br><br>
 
-This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top-level account](/docs/concepts/account#top-level-accounts) if the length of an account is greater than 31 characters; most commonly used for [implicit account](/docs/concepts/account#implicit-accounts) creation.
+This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top-level account](/docs/concepts/account#top-level-accounts) if the length of the account ID is greater than 31 characters. This is most commonly used for [implicit account](/docs/concepts/account#implicit-accounts) creation.
 
 If you are looking to create a top-level `.testnet` or `.near` account you can do so using `near-api-js` [ [**here**](/docs/api/naj-cookbook#create-account) ].
 

--- a/docs/tools/near-cli.md
+++ b/docs/tools/near-cli.md
@@ -506,7 +506,12 @@ near delete-key example-acct.testnet Cxg2wgFYrdLTEkMu6j5D6aEZqTb3kXbmJygS48ZKbo1
 - arguments: `accountId` `--masterAccount`
 - options: `--initialBalance`
 
-**Note:** This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top-level account](/docs/concepts/account#top-level-accounts) if the length of an account is greater than 31 characters; most commonly for [implicit account](/docs/concepts/account#implicit-accounts) creation.
+<blockquote class="warning">
+<strong>heads up</strong><br><br>
+
+This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top-level account](/docs/concepts/account#top-level-accounts) if the length of an account is greater than 31 characters; most commonly used for [implicit account](/docs/concepts/account#implicit-accounts) creation.
+
+</blockquote>
 
 **Example**:
 

--- a/docs/tools/near-cli.md
+++ b/docs/tools/near-cli.md
@@ -506,7 +506,7 @@ near delete-key example-acct.testnet Cxg2wgFYrdLTEkMu6j5D6aEZqTb3kXbmJygS48ZKbo1
 - arguments: `accountId` `--masterAccount`
 - options: `--initialBalance`
 
-**Note:** This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top level account](/docs/concepts/account#top-level-accounts) if the length of an account is greater than 31 characters; most commonly for [implicit account](/docs/concepts/account#implicit-accounts) creation.
+**Note:** This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top-level account](/docs/concepts/account#top-level-accounts) if the length of an account is greater than 31 characters; most commonly for [implicit account](/docs/concepts/account#implicit-accounts) creation.
 
 **Example**:
 

--- a/docs/tools/near-cli.md
+++ b/docs/tools/near-cli.md
@@ -511,6 +511,8 @@ near delete-key example-acct.testnet Cxg2wgFYrdLTEkMu6j5D6aEZqTb3kXbmJygS48ZKbo1
 
 This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top-level account](/docs/concepts/account#top-level-accounts) if the length of an account is greater than 31 characters; most commonly used for [implicit account](/docs/concepts/account#implicit-accounts) creation.
 
+If you are looking to create a top-level `.testnet` or `.near` account you can do so using `near-api-js` [ [**here**](/docs/api/naj-cookbook#create-account) ].
+
 </blockquote>
 
 **Example**:

--- a/docs/tools/near-cli.md
+++ b/docs/tools/near-cli.md
@@ -506,12 +506,12 @@ near delete-key example-acct.testnet Cxg2wgFYrdLTEkMu6j5D6aEZqTb3kXbmJygS48ZKbo1
 - arguments: `accountId` `--masterAccount`
 - options: `--initialBalance`
 
-**Note:** You will only be able to create subaccounts of the `--masterAccount` unless the name of the new account is ≥ 32 characters.
+**Note:** This command will only allow the creation of [subaccounts](/docs/concepts/account#subaccounts) of the `--masterAccount`. You can, however, create a [top level account](/docs/concepts/account#top-level-accounts) if the length of an account is greater than 31 characters; most commonly for [implicit account](/docs/concepts/account#implicit-accounts) creation.
 
 **Example**:
 
 ```bash
-near create-account 12345678901234567890123456789012 --masterAccount example-acct.testnet
+near create-account 7e094afcfc4eda8a970f6648cdf0dbd6de --masterAccount example-acct.testnet
 ```
 
 **Subaccount example:**


### PR DESCRIPTION
Updates details on how to use `near create-account` primarily around the difference in sub-accounts, top-level accounts, and implicit accounts.