### PR TITLE
Update documentation to mention `make neard`

### DIFF
--- a/docs/develop/node/archival/run-archival-node-without-nearup.md
+++ b/docs/develop/node/archival/run-archival-node-without-nearup.md
@@ -50,7 +50,6 @@ First, clone the [`nearcore` repository](https://github.com/near/nearcore).
 ```bash
 $ git clone https://github.com/near/nearcore
 $ git fetch origin --tags
-$ cd nearcore
 ```
 
 Checkout to the branch you need if not `master` (default). Latest release is recommended. Please check the [releases page on GitHub](https://github.com/near/nearcore/releases).
@@ -64,12 +63,18 @@ $ git checkout tags/1.19.0 -b mynode
 In the `nearcore` folder run the following commands:
 
 ```bash
-$ cargo build --release --package neard --bin neard
+$ make release
 ```
 
 This will start the compilation process. It will take some time depending on your machine power _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
 
-The binary path is `nearcore/target/release/neard`
+By the way, if you’re familiar with Cargo, you could wonder why not
+run `cargo build -p neard --release` instead.  While this will produce
+a binary, the result will be a less optimised version.  On technical
+level, this is because building via `make neard` enables link-time
+optimisation which is disabled by default.
+
+The binary path is `target/release/neard`
 
 ### 3. Initialize working directory
 
@@ -167,7 +172,6 @@ First, clone the [`nearcore` repository](https://github.com/near/nearcore).
 ```bash
 $ git clone https://github.com/near/nearcore
 $ git fetch origin --tags
-$ cd nearcore
 ```
 
 Next, checkout the release branch you need (recommended) if you will not be using the default `master` branch. Please check the [releases page on GitHub](https://github.com/near/nearcore/releases) for the latest release.
@@ -183,12 +187,18 @@ $ git checkout tags/1.19.0 -b mynode
 In the `nearcore` folder run the following commands:
 
 ```bash
-$ cargo build --release --package neard --bin neard
+$ make release
 ```
 
 This will start the compilation process and will take some time depending on your machine's CPU power. _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
 
-The binary path is `nearcore/target/release/neard`
+By the way, if you’re familiar with Cargo, you could wonder why not
+run `cargo build -p neard --release` instead.  While this will produce
+a binary, the result will be a less optimised version.  On technical
+level, this is because building via `make neard` enables link-time
+optimisation which is disabled by default.
+
+The binary path is `target/release/neard`
 
 ### 3. Initialize working directory
 

--- a/docs/develop/node/validator/compile-and-run-a-node.md
+++ b/docs/develop/node/validator/compile-and-run-a-node.md
@@ -49,7 +49,6 @@ First, clone the [`nearcore` repository](https://github.com/near/nearcore).
 
 ```bash
 $ git clone https://github.com/near/nearcore
-$ cd nearcore
 ```
 
 Next, checkout the release branch you need if you will not be using the default `master` branch. [ [More info](/docs/develop/node/validator/compile-and-run-a-node#choosing-your-nearcore-version) ]
@@ -60,15 +59,21 @@ $ git checkout master
 
 ### 2. Compile `nearcore` binary
 
-In the `nearcore` folder run the following commands:
+In the repository run the following commands:
 
 ```bash
-$ cargo build --release --package neard --bin neard
+$ make neard
 ```
 
 This will start the compilation process. It will take some time depending on your machine's cpu power. _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
 
-The binary path is `nearcore/target/release/neard`
+By the way, if you’re familiar with Cargo, you could wonder why not
+run `cargo build -p neard --release` instead.  While this will produce
+a binary, the result will be a less optimised version.  On technical
+level, this is because building via `make neard` enables link-time
+optimisation which is disabled by default.
+
+The binary path is `target/release/neard`
 
 ### 3. Initialize working directory
 
@@ -110,7 +115,6 @@ First, clone the [`nearcore` repository](https://github.com/near/nearcore).
 ```bash
 $ git clone https://github.com/near/nearcore
 $ git fetch origin --tags
-$ cd nearcore
 ```
 
 Checkout to the branch you need if not `master` (default). Latest release is recommended. Please check the [releases page on GitHub](https://github.com/near/nearcore/releases). Current latest is `1.19.0`
@@ -124,12 +128,18 @@ $ git checkout tags/1.19.0 -b mynode
 In the `nearcore` folder run the following commands:
 
 ```bash
-$ cargo build --release --package neard --bin neard
+$ make release
 ```
 
 This will start the compilation process. It will take some time depending on your machine power _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
 
-The binary path is `nearcore/target/release/neard`
+By the way, if you’re familiar with Cargo, you could wonder why not
+run `cargo build -p neard --release` instead.  While this will produce
+a binary, the result will be a less optimised version.  On technical
+level, this is because building via `make release` enables link-time
+optimisation which is disabled by default.
+
+The binary path is `target/release/neard`
 
 ### 3. Initialize working directory
 
@@ -205,7 +215,6 @@ First, clone the [`nearcore` repository](https://github.com/near/nearcore).
 ```bash
 $ git clone https://github.com/near/nearcore
 $ git fetch origin --tags
-$ cd nearcore
 ```
 
 Next, checkout the release branch you need (recommended) if you will not be using the default `master` branch. Please check the [releases page on GitHub](https://github.com/near/nearcore/releases) for the latest release.
@@ -221,12 +230,18 @@ $ git checkout tags/1.19.0 -b mynode
 In the `nearcore` folder run the following commands:
 
 ```bash
-$ cargo build --release --package neard --bin neard
+$ make release
 ```
 
 This will start the compilation process and will take some time depending on your machine's CPU power. _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
 
-The binary path is `nearcore/target/release/neard`
+By the way, if you’re familiar with Cargo, you could wonder why not
+run `cargo build -p neard --release` instead.  While this will produce
+a binary, the result will be a less optimised version.  On technical
+level, this is because building via `make release` enables link-time
+optimisation which is disabled by default.
+
+The binary path is `target/release/neard`
 
 ### 3. Initialize working directory
 


### PR DESCRIPTION
We are planning to disable LTO in Cargo.toml which means that
`cargo build --release` will produce less optimised binaries (but
do it faster).  Point at `make neard` in the documentation to make
sure that anyone intending to run node in production gets best
optimised version as before.

The `make neard` target produces the `neard` binary but it has been
added only recently† and is not available when building older
releases.  Because of that, when documentation mentions checking out
non-HEAD commits points at `make release` instead.  It builds a few
more targets so it is slower but it does produce `neard`.

Note that docs/community/contribute/nearcore.md file has been left
unchanged because it describes development process (rather than
running the node in production) and in that case we want people to
build via `cargo build` et al which is much faster‡.

† https://github.com/near/nearcore/pull/4510
‡ https://github.com/near/nearcore/pull/4507

Issue: https://github.com/near/nearcore/issues/4403
