### PR TITLE
Mention memory requirements for a release build in a few places

### DIFF
--- a/docs/develop/node/archival/run-archival-node-without-nearup.md
+++ b/docs/develop/node/archival/run-archival-node-without-nearup.md
@@ -66,7 +66,12 @@ In the `nearcore` folder run the following commands:
 $ make release
 ```
 
-This will start the compilation process. It will take some time depending on your machine power _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
+This will start the compilation process. It will take some time
+depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
+takes approximately 25 minutes). Note that compilation will need over
+1 GB of memory per virtual core the machine has. If the build fails
+with processes being killed, you might want to try reducing number of
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce
@@ -190,7 +195,12 @@ In the `nearcore` folder run the following commands:
 $ make release
 ```
 
-This will start the compilation process and will take some time depending on your machine's CPU power. _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
+This will start the compilation process. It will take some time
+depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
+takes approximately 25 minutes). Note that compilation will need over
+1 GB of memory per virtual core the machine has. If the build fails
+with processes being killed, you might want to try reducing number of
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce

--- a/docs/develop/node/validator/compile-and-run-a-node.md
+++ b/docs/develop/node/validator/compile-and-run-a-node.md
@@ -65,7 +65,12 @@ In the repository run the following commands:
 $ make neard
 ```
 
-This will start the compilation process. It will take some time depending on your machine's cpu power. _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
+This will start the compilation process. It will take some time
+depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
+takes approximately 25 minutes). Note that compilation will need over
+1 GB of memory per virtual core the machine has. If the build fails
+with processes being killed, you might want to try reducing number of
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce
@@ -131,7 +136,12 @@ In the `nearcore` folder run the following commands:
 $ make release
 ```
 
-This will start the compilation process. It will take some time depending on your machine power _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
+This will start the compilation process. It will take some time
+depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
+takes approximately 25 minutes). Note that compilation will need over
+1 GB of memory per virtual core the machine has. If the build fails
+with processes being killed, you might want to try reducing number of
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce
@@ -233,7 +243,12 @@ In the `nearcore` folder run the following commands:
 $ make release
 ```
 
-This will start the compilation process and will take some time depending on your machine's CPU power. _(e.g. i9 8-core CPU, 32 GB RAM, SSD takes approximately 25 minutes)_
+This will start the compilation process. It will take some time
+depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
+takes approximately 25 minutes). Note that compilation will need over
+1 GB of memory per virtual core the machine has. If the build fails
+with processes being killed, you might want to try reducing number of
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce

--- a/docs/develop/node/validator/running-a-node-macos-linux.md
+++ b/docs/develop/node/validator/running-a-node-macos-linux.md
@@ -110,6 +110,11 @@ If you are running a validator in production you may find it more
 efficient to just build `neard`.  This can be done with `make neard`
 command.
 
+Note that compilation will need over 1 GB of memory per virtual core
+the machine has. If the build fails with processes being killed, you
+might want to try reducing number of parallel jobs, for example:
+`CARGO_BUILD_JOBS=8 make release`.
+
 NB. Please ensure you build releases through `make` rather than `cargo
 build --release`.  The latter skips some optimisations (most notably
 link-time optimisation) and thus produces a less efficient executable.


### PR DESCRIPTION
as well as the CARGO_BUILD_JOBS environment variable which can be
used to reduce number of parallel jobs.

Issue: https://github.com/near/nearcore/issues/4538