### PR TITLE
Fixes error in neard init argument

### DIFF
--- a/docs/develop/node/validator/compile-and-run-a-node.md
+++ b/docs/develop/node/validator/compile-and-run-a-node.md
@@ -270,7 +270,7 @@ In order to work NEAR node requires to have working directory and a couple of co
 Generate the initial required working directory by running:
 
 ```bash
-$ ./target/release/neard --home ~/.near init --chain-id mainnet --download-genesis
+$ ./target/release/neard --home ~/.near init --chain-id mainnet
 ```
 
 > You can skip the `--home` argument if you are fine with the default working directory in `~/.near`. If not, pass your preferred location.

--- a/docs/develop/node/validator/compile-and-run-a-node.md
+++ b/docs/develop/node/validator/compile-and-run-a-node.md
@@ -163,7 +163,7 @@ In order to work properly, the NEAR node requires a working directory and a coup
 Generate the initial required working directory by running:
 
 ```bash
-$ ./target/release/neard --home ~/.near init --chain-id testnet --download
+$ ./target/release/neard --home ~/.near init --chain-id testnet --download-genesis
 ```
 
 > You can skip the `--home` argument if you are fine with the default working directory in `~/.near`. If not, pass your preferred location.
@@ -270,7 +270,7 @@ In order to work NEAR node requires to have working directory and a couple of co
 Generate the initial required working directory by running:
 
 ```bash
-$ ./target/release/neard --home ~/.near init --chain-id mainnet --download
+$ ./target/release/neard --home ~/.near init --chain-id mainnet --download-genesis
 ```
 
 > You can skip the `--home` argument if you are fine with the default working directory in `~/.near`. If not, pass your preferred location.


### PR DESCRIPTION
When running as documented, neard returns an error:

```
error: Found argument '--download' which wasn't expected, or isn't valid in this context

Did you mean '--download-genesis'?
```

This change updates the doc to the proper argument