### PR TITLE
Restore data backup to expected directory

### DIFF
--- a/docs/develop/node/validator/compile-and-run-a-node.md
+++ b/docs/develop/node/validator/compile-and-run-a-node.md
@@ -199,9 +199,10 @@ or
 2. Run the following commands:
 
 ```bash
-$ wget ~/.near/data.tar https://near-protocol-public.s3.ca-central-1.amazonaws.com/backups/testnet/rpc/data.tar
-$ tar -xf ~/.near/data.tar
-$ rm ~/.near/data.tar
+$ mkdir -p ~/.near/data
+$ wget ~/.near/data/data.tar https://near-protocol-public.s3.ca-central-1.amazonaws.com/backups/testnet/rpc/data.tar
+$ tar -xf ~/.near/data/data.tar
+$ rm ~/.near/data/data.tar
 ```
 
 NOTE: The .tar file is ~32GB (and will grow) so make sure you have enough disk space to unpack inside the data folder.
@@ -304,9 +305,10 @@ or
 2. Run the following commands:
 
 ```bash
-$ wget ~/.near/data.tar https://near-protocol-public.s3.ca-central-1.amazonaws.com/backups/mainnet/rpc/data.tar
-$ tar -xf ~/.near/data.tar
-$ rm ~/.near/data.tar
+$ mkdir -p ~/.near/data
+$ wget ~/.near/data/data.tar https://near-protocol-public.s3.ca-central-1.amazonaws.com/backups/mainnet/rpc/data.tar
+$ tar -xf ~/.near/data/data.tar
+$ rm ~/.near/data/data.tar
 ```
 
 NOTE: The .tar file is ~125GB (and will grow) so make sure you have enough disk space to unpack inside the data folder.


### PR DESCRIPTION
When executing the bash commands as documented, all of the files in the backup archive end up extracted into the top level of the near home directory. On first start of neard, it then creates a new data structure in near home/data and begins to sync with peers from the beginning. The updates in this commit extract the archive into the expected /data directory and allow the synchronization to start from the last back up.