### PR TITLE
Validator documentation update

### DIFF
--- a/docs/develop/node/validator/compile-and-run-a-node.md
+++ b/docs/develop/node/validator/compile-and-run-a-node.md
@@ -240,7 +240,7 @@ $ git checkout tags/1.20.0 -b mynode
 In the `nearcore` folder run the following commands:
 
 ```bash
-$ make release
+$ make neard
 ```
 
 This will start the compilation process. It will take some time
@@ -248,12 +248,12 @@ depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
 takes approximately 25 minutes). Note that compilation will need over
 1 GB of memory per virtual core the machine has. If the build fails
 with processes being killed, you might want to try reducing number of
-parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce
 a binary, the result will be a less optimised version.  On technical
-level, this is because building via `make release` enables link-time
+level, this is because building via `make neard` enables link-time
 optimisation which is disabled by default.
 
 The binary path is `target/release/neard`

--- a/docs/develop/node/validator/compile-and-run-a-node.md
+++ b/docs/develop/node/validator/compile-and-run-a-node.md
@@ -70,7 +70,7 @@ depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
 takes approximately 25 minutes). Note that compilation will need over
 1 GB of memory per virtual core the machine has. If the build fails
 with processes being killed, you might want to try reducing number of
-parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce
@@ -133,7 +133,7 @@ $ git checkout tags/1.20.0 -b mynode
 In the `nearcore` folder run the following commands:
 
 ```bash
-$ make release
+$ make neard
 ```
 
 This will start the compilation process. It will take some time
@@ -141,12 +141,12 @@ depending on your machine power (e.g. i9 8-core CPU, 32 GB RAM, SSD
 takes approximately 25 minutes). Note that compilation will need over
 1 GB of memory per virtual core the machine has. If the build fails
 with processes being killed, you might want to try reducing number of
-parallel jobs, for example: `CARGO_BUILD_JOBS=8 make release`.
+parallel jobs, for example: `CARGO_BUILD_JOBS=8 make neard`.
 
 By the way, if you’re familiar with Cargo, you could wonder why not
 run `cargo build -p neard --release` instead.  While this will produce
 a binary, the result will be a less optimised version.  On technical
-level, this is because building via `make release` enables link-time
+level, this is because building via `make neard` enables link-time
 optimisation which is disabled by default.
 
 The binary path is `target/release/neard`

--- a/docs/develop/node/validator/deploy-on-mainnet.md
+++ b/docs/develop/node/validator/deploy-on-mainnet.md
@@ -5,7 +5,7 @@ sidebar_label: Deploy Node on Mainnet
 ---
 
 
-Deploying a node on `mainnet` is similar to deploying on `testnet` and `localnet`:
+Deploying a node on `mainnet` is similar to deploying on `testnet`:
 1. Create your `mainnet` wallet
 2. Deploy your `mainnet` staking pool
 3. Build and run your `mainnet` validator node

--- a/docs/develop/node/validator/deploy-on-mainnet.md
+++ b/docs/develop/node/validator/deploy-on-mainnet.md
@@ -61,7 +61,7 @@ git checkout $NEAR_RELEASE_VERSION
   optimised executable):
 
 ```bash
-make release
+make neard
 ```
 
 - configure the `chain-id` and `account-id`:

--- a/docs/develop/node/validator/deploy-on-mainnet.md
+++ b/docs/develop/node/validator/deploy-on-mainnet.md
@@ -5,15 +5,15 @@ sidebar_label: Deploy Node on Mainnet
 ---
 
 
-Deploying a node on mainnet is similar to deploying on testnet and betanet:
-1. Create your mainnet wallet
-2. Deploy your mainnet staking pool
-3. Build and run your mainnet validator node
+Deploying a node on `mainnet` is similar to deploying on `testnet` and `localnet`:
+1. Create your `mainnet` wallet
+2. Deploy your `mainnet` staking pool
+3. Build and run your `mainnet` validator node
 
-### 1. Create your mainnet Wallet
+### 1. Create your `mainnet` Wallet
 - Go to [wallet.near.org](https://wallet.near.org/) and create an account.
 
-### 2. Deploy your mainnet Staking Pool
+### 2. Deploy your `mainnet` Staking Pool
 You can instantly deploy the staking pool with [near-cli](https://github.com/near/near-cli), using the command `near call`:
 
 ```

--- a/docs/develop/node/validator/running-a-node-macos-linux.md
+++ b/docs/develop/node/validator/running-a-node-macos-linux.md
@@ -138,15 +138,15 @@ git checkout <version>
 You can then run:
 
 ```bash
-make release
+make neard
 ```
 
-This will compile all the binaries for the version you have checked out, including tools such as the `keypair-generator`; they will be available under `target/release/`.
+This will compile the `neard` binary for the version you have checked out, it will be available under `target/release/neard`.
 
 Note that compilation will need over 1 GB of memory per virtual core
 the machine has. If the build fails with processes being killed, you
 might want to try reducing number of parallel jobs, for example:
-`CARGO_BUILD_JOBS=8 make release`.
+`CARGO_BUILD_JOBS=8 make neard`.
 
 NB. Please ensure you build releases through `make` rather than `cargo
 build --release`.  The latter skips some optimisations (most notably

--- a/docs/develop/node/validator/running-a-node-windows.md
+++ b/docs/develop/node/validator/running-a-node-windows.md
@@ -86,7 +86,7 @@ The README for `nearup` (linked above) may be **all you need to get a node up an
     ```sh
     curl -s https://rpc.testnet.near.org/status | jq .version
     ```
-    You’ll get something like this: "1.13.0-rc.2". "1.13.0" is a branch which we need to clone to build our node `fortestnet`.
+    You’ll get something like this: "1.13.0-rc.2". "1.13.0" is a branch which we need to clone to build our node for `testnet`.
 
     ```sh
     git clone --branch 1.13.0 https://github.com/near/nearcore.git

--- a/docs/develop/node/validator/running-a-node-windows.md
+++ b/docs/develop/node/validator/running-a-node-windows.md
@@ -20,7 +20,7 @@ You can install `nearup` by following the instructions at https://github.com/nea
 <blockquote class="info">
 <strong>Heads up</strong><br><br>
 
-The README for `nearup` (linked above) may be **all you need to get a node up and running** in `betanet` and `testnet`. `nearup` is exclusively used to launch NEAR `betanet` and `testnet` nodes. `nearup` is not used to launch `mainnet` nodes.
+The README for `nearup` (linked above) may be **all you need to get a node up and running** in `testnet` and `localnet`. `nearup` is exclusively used to launch NEAR `testnet` and `localnet` nodes. `nearup` is not used to launch `mainnet` nodes. See [Deploy Node on Mainnet](deploy-on-mainnet) for running a node on `mainnet`.
 
 </blockquote>
 
@@ -82,11 +82,11 @@ The README for `nearup` (linked above) may be **all you need to get a node up an
     Great! All set to get the node up and running!
 11. Clone the github nearcore
 
-    First we need to check a version which is currently working in testnet:
+    First we need to check a version which is currently working in `testnet`:
     ```sh
     curl -s https://rpc.testnet.near.org/status | jq .version
     ```
-    You’ll get something like this: "1.13.0-rc.2". "1.13.0" is a branch which we need to clone to build our node for testnet.
+    You’ll get something like this: "1.13.0-rc.2". "1.13.0" is a branch which we need to clone to build our node `fortestnet`.
 
     ```sh
     git clone --branch 1.13.0 https://github.com/near/nearcore.git
@@ -101,11 +101,11 @@ The README for `nearup` (linked above) may be **all you need to get a node up an
     pip3 install --user nearup
     export PATH="$HOME/.local/bin:$PATH"
     ```
-14. Final: And now run the testnet:
+14. Final: And now run the `testnet`:
     ```sh
-    nearup run testnet --binary-path ~/nearcore/target/release/
+    nearup run testnet --binary-path ~/nearcore/target/release/neard
     ```
-    To be sure node is ruuning you can check logs
+    To be sure node is running you can check logs
     ```sh
     nearup logs --follow
     ```

--- a/docs/develop/node/validator/running-a-node-windows.md
+++ b/docs/develop/node/validator/running-a-node-windows.md
@@ -94,7 +94,7 @@ The README for `nearup` (linked above) may be **all you need to get a node up an
 12. This created a nearcore directory, change into that one and build a noce:
     ```sh
     cd nearcore
-    make release
+    make neard
     ```
 13. Install nearup
     ```sh


### PR DESCRIPTION
* Fix docker and no-docker instructions for nearup.
* Remove references to betanet.
* Replace hardware requirements with a link to the hardware requirements page.
* Clarify nearup instructions refer to non-mainnet use case.
* Fix a few typos and formatting issues.

Fixes #778 