### PR TITLE
Add links to NEAR's Wiki

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -230,6 +230,9 @@ class Footer extends React.Component {
                     <li className="menu-item menu-item-type-custom menu-item-object-custom menu-item-6804">
                       <a href="https://gov.near.org/">Forum</a>
                     </li>
+                    <li className="menu-item menu-item-type-custom menu-item-object-custom menu-item-6804">
+                      <a href="https://wiki.near.org/">Wiki</a>
+                    </li>
                     <li className="menu-item menu-item-type-custom menu-item-object-custom menu-item-4650">
                       <a href="https://near.org/events">Events</a>
                     </li>

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -56,6 +56,11 @@ class Footer extends React.Component {
                     Examples
                   </a>
                 </li>
+                <li>
+                  <a href="https://wiki.near.org/" className="hover:text-white">
+                    Wiki
+                  </a>
+                </li>
               </ul>
             </div>
             <div className="col md:w-3/4 mt-50 md:mt-0">
@@ -229,9 +234,6 @@ class Footer extends React.Component {
                   >
                     <li className="menu-item menu-item-type-custom menu-item-object-custom menu-item-6804">
                       <a href="https://gov.near.org/">Forum</a>
-                    </li>
-                    <li className="menu-item menu-item-type-custom menu-item-object-custom menu-item-6804">
-                      <a href="https://wiki.near.org/">Wiki</a>
                     </li>
                     <li className="menu-item menu-item-type-custom menu-item-object-custom menu-item-4650">
                       <a href="https://near.org/events">Events</a>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -14,7 +14,7 @@ const siteConfig = {
     { doc: "tutorials/create-transactions", label: "Tutorials" },
     { doc: "api/rpc", label: "API" },
     { search: true },
-    { doc: "validator/staking-overview", label: "Tokens/Staking" },
+    { href: "https://wiki.near.org/validator/validator-overview", label: "Tokens/Staking", external: true },
     { doc: "roles/integrator/exchange-integration", label: "Exchanges" },
     { doc: "community/community-channels", label: "Community" }
   ],


### PR DESCRIPTION
This PR adds links to the new Wiki (https://github.com/near/devrel/issues/255):

- Redirects `Staking` header link to the wiki
- Adds footer link to Wiki