### PR TITLE
Explained how to deal with empty method args for near cli

### DIFF
--- a/docs/tools/near-cli.md
+++ b/docs/tools/near-cli.md
@@ -691,6 +691,8 @@ near dev-deploy out/main.wasm
 - arguments: `contractName` `method_name` `{ args }` `--accountId`
 - options: `--gas` `--deposit` `--depositYocto`
 
+**Note:** There are two ways to deal with methods that require empty `{ args }`. Either send `{"field": null}` or simply omit this field and pass in nothing: `{}`
+
 **Example:**
 
 ```bash
@@ -759,7 +761,6 @@ OR
 ```bash
 near view-state dao.sputnik-v2.testnet --block-id 53199035
 ```
-
 
 <details>
 <summary>**Example Response:**</summary>
@@ -1255,7 +1256,7 @@ With NEAR REPL, you have complete access to [`near-api-js`](https://github.com/n
 | `--verbose`, `-v`             | shows verbose output                                                                                                                   |
 | `--gas`                       | specifies amount of gas to use for a contract call `[default: "100000000000000"]`                                                      |
 | `--deposit`                   | Number of NEAR tokens (Ⓝ) to attach `[default: "0"]`                                                                                   |
-| `--depositYocto`              | Number of tokens to attach (in yocto Ⓝ) to a function call `[default: null]`                                                          |
+| `--depositYocto`              | Number of tokens to attach (in yocto Ⓝ) to a function call `[default: null]`                                                           |
 
 > Got a question?
 > <a href="https://stackoverflow.com/questions/tagged/nearprotocol"> > <h8>Ask it on StackOverflow!</h8></a>


### PR DESCRIPTION
Added note saying: 

**Note:** There are two ways to deal with methods that require empty `{ args }`. Either send `{"field": null}` or simply omit this field and pass in nothing: `{}`

in the near-cli near call section. 