### PR TITLE
Fixed inconsistent naming between NEAR and Near

### DIFF
--- a/docs/community/contribute/nearcore.md
+++ b/docs/community/contribute/nearcore.md
@@ -1,6 +1,6 @@
 ---
 id: contribute-nearcore
-title: Contribute to NearCore
+title: Contribute to nearcore
 sidebar_label: NearCore Contributions
 ---
 

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -12,8 +12,8 @@ It’s a community-operated Cloud, providing a platform for building open source
 #### Blockchain answer:
 It’s a decentralized application platform running on its own blockchain, that solves usability and scaling via sharding.
 
-### What is the difference between Near Inc and the NEAR Protocol?
-Generally, we differentiate between many of the different entities who are building the NEAR platform. Two of those different entities are the NEAR Foundation and Near Inc.
+### What is the difference between NEAR Inc and the NEAR Protocol?
+Generally, we differentiate between many of the different entities who are building the NEAR platform. Two of those different entities are the NEAR Foundation and NEAR Inc.
 
 #### The NEAR Protocol
 A permissionless, Proof-of-Stake blockchain protocol that anyone can access, add transactions to, or read from. The public NEAR blockchain is an instantiation of the reference code at http://github.com/near/nearcore, but theoretically, this repo could be forked and deployed as a separate chain, as much as many protocols have done to build upon the core Bitcoin code.
@@ -21,11 +21,11 @@ A permissionless, Proof-of-Stake blockchain protocol that anyone can access, add
 #### The NEAR Foundation
 A non-profit foundation headquartered in Switzerland, and is responsible for contracting protocol maintainers, funding ecosystem development, and shepherding core governance of the protocol.
 
-#### Near Inc
-A US-based software research and development company that did much of the early development of the protocol and its tooling. While Near Inc does not own or run the NEAR Protocol (which is decentralized), it continues to propose changes to the reference implementation codebase as one of multiple third-party entities performing R&D work for the protocol.
+#### NEAR Inc
+A US-based software research and development company that did much of the early development of the protocol and its tooling. While NEAR Inc does not own or run the NEAR Protocol (which is decentralized), it continues to propose changes to the reference implementation codebase as one of multiple third-party entities performing R&D work for the protocol.
 
 ### Who is building the NEAR Protocol?
-Much of the early development of the protocol and its tooling has been done by Near Inc.
+Much of the early development of the protocol and its tooling has been done by NEAR Inc.
 
 ### Where can I learn more about NEAR?
 It really depends on what you want to learn more about.
@@ -52,9 +52,9 @@ You want to receive updates on the latest and greatest in the NEAR ecosystem, th
 # Contributing to NEAR
 
 ### How can I get involved?
-It depends on what you are excited about doing. Do you want to develop on Near? Build tutorials? Answer questions? Expand our documentation? We recommend you have a look at our [Contributor Program](http://near.org/contributor). If you are looking for something a little different, or you have questions, please reach out to the team on [Telegram](https://t.me/cryptonear) or [Discord](http://near.chat/).
+It depends on what you are excited about doing. Do you want to develop on NEAR? Build tutorials? Answer questions? Expand our documentation? We recommend you have a look at our [Contributor Program](http://near.org/contributor). If you are looking for something a little different, or you have questions, please reach out to the team on [Telegram](https://t.me/cryptonear) or [Discord](http://near.chat/).
 
-### Does Near have a bug bounty program available?
+### Does NEAR have a bug bounty program available?
 While we currently do not have a bug bounty program, you can contribute to our development of resources through our [Contributor Program](http://near.org/contributor). Additionally, we have hosted several hackathons; for future events sign-up to our newsletter https://near.org/newsletter/
 
 ### Are articles (not NEAR-specific) allowed to be shared on Discord or Telegram?

--- a/docs/concepts/account.md
+++ b/docs/concepts/account.md
@@ -25,7 +25,7 @@ Top-level account names (TLAs) are very valuable as they provide root of trust a
 
 Specifically, only `REGISTRAR_ACCOUNT_ID` account can create new top-level accounts that are shorter than `MIN_ALLOWED_TOP_LEVEL_ACCOUNT_LENGTH` characters. `REGISTRAR_ACCOUNT_ID` implements a standard `Account Naming` interface which allow it to create new accounts.
 
-We are not going to deploy the `registrar` auction at launch. Instead we will allow it to be deployed by the Near Foundation at some point in the future.
+We are not going to deploy the `registrar` auction at launch. Instead we will allow it to be deployed by the NEAR Foundation at some point in the future.
 
 Currently all `mainnet` accounts use a `near` top-level account name (ex `example.near`) and all `testnet` accounts use a `testnet` top-level account (ex. `example.testnet`).
 

--- a/docs/concepts/gas.md
+++ b/docs/concepts/gas.md
@@ -216,7 +216,7 @@ This is also true for basic operations. In the previous section we mentioned tha
 
 ## What about Prepaid Gas?
 
-The Near Team understands that developers want to provide their users with the best possible onboarding experience. To realize this vision, developers can design their applications in a way that first-time users can draw funds for purchasing gas directly from an account maintained by the developer. Once onboarded, users can then transition to paying for their own platform use.
+The NEAR Team understands that developers want to provide their users with the best possible onboarding experience. To realize this vision, developers can design their applications in a way that first-time users can draw funds for purchasing gas directly from an account maintained by the developer. Once onboarded, users can then transition to paying for their own platform use.
 
 In this sense, prepaid gas can be realized using a funded account and related contract(s) for onboarding new users.
 

--- a/docs/concepts/new-to-near.md
+++ b/docs/concepts/new-to-near.md
@@ -104,7 +104,7 @@ Luckily, there are plenty of tools available in these docs to test-drive these t
 [ [View](https://stackoverflow.com/tags/nearprotocol) ] new questions and answers published regularly
 
 - Could we consider non-plugins web-based crypto wallets as safe? ([view](https://stackoverflow.com/questions/59165184/could-we-consider-non-plugins-web-based-crypto-wallets-as-safe))
-- How to print the length of an array in AssemblyScript / Near? ([view](https://stackoverflow.com/questions/57897731/how-to-print-the-length-of-an-array-in-assemblyscript-near))
+- How to print the length of an array in AssemblyScript / NEAR? ([view](https://stackoverflow.com/questions/57897731/how-to-print-the-length-of-an-array-in-assemblyscript-near))
 - Changing VMContext attributes during tests ([view](https://stackoverflow.com/questions/58956740/changing-vmcontext-attributes-during-tests))
 - String attribute set in init method always returns empty string ([view](https://stackoverflow.com/questions/58659873/string-attribute-set-in-init-method-always-returns-empty-string))
 - How to attach value (deposit) to transaction with near-api-js? ([view](https://stackoverflow.com/questions/57904221/how-to-attach-value-deposit-to-transaction-with-near-api-js))

--- a/docs/develop/contracts/rust/intro.md
+++ b/docs/develop/contracts/rust/intro.md
@@ -193,7 +193,7 @@ Next, replace the content with the following [`Cargo.toml`](https://github.com/n
 [package]
 name = "rust-counter-tutorial"
 version = "0.1.0"
-authors = ["Near Inc <hello@near.org>"]
+authors = ["NEAR Inc <hello@near.org>"]
 edition = "2018"
 
 [lib]

--- a/docs/develop/front-end/introduction.md
+++ b/docs/develop/front-end/introduction.md
@@ -385,7 +385,7 @@ And at least one key will look like this with `FullAccess` permissions (your pub
 - vue-near
   - A simple vuejs plugin, binding near-api-js into components with 1 line of code. [source code & install](https://github.com/TrevorJTClarke/vue-near/)
 
-### Built With Near
+### Built With NEAR
 
 - CryptoCorgies
   - [try](https://github.com/nearprotocol/corgis) our delightful clone of the famous CryptoKitties application that brought the Ethereum network to a grinding halt.

--- a/docs/faq/developer-faq.md
+++ b/docs/faq/developer-faq.md
@@ -128,7 +128,7 @@ const keypair = nearApi.utils.key_pair.KeyPair.fromString(
 
 While theoretically any language that can be compiled to Wasm can be supported, in reality we often need a smart contract library to wrap around low-level runtime APIs as well as providing some other high-level functionalities.
 
-Right now, we support Rust and AssemblyScript. To support the functionality needed while ensuring the best user experience requires time, testing, and iteration. We envision that in the future, more languages will be supported and the support will be done through the effort from the wider community, not just Near alone.
+Right now, we support Rust and AssemblyScript. To support the functionality needed while ensuring the best user experience requires time, testing, and iteration. We envision that in the future, more languages will be supported and the support will be done through the effort from the wider community, not just NEAR alone.
 
 If you have a language you love, take a look a our [JSON RPC API](/docs/api/rpc), the primary interface for interacting with the blockchain. You can refer to [`near-api-js`, our JavaScript library.](https://github.com/near/near-api-js/tree/master/src) for inspiration and reference on the abstractions we use for JavaScript developers.
 

--- a/docs/roles/integrator/faq.md
+++ b/docs/roles/integrator/faq.md
@@ -176,7 +176,7 @@ _You can read more in our [Nightshade whitepaper](https://near.org/downloads/Nig
 > _A few relevant details have been extracted here for convenience:_
 >
 > [Since NEAR is a sharded blockchain, there are challenges that need to be overcome] including state validity and data
-> availability problems. _Nightshade_ is the solution Near Protocol is built upon that addresses these issues.
+> availability problems. _Nightshade_ is the solution NEAR Protocol is built upon that addresses these issues.
 >
 > Nightshade uses the heaviest chain consensus. Specifically when a block producer produces a block (see section 3.3), they can collect signatures from other block producers and validators attesting to the previous block. The weight of a block is then the cumulative stake of all the signers whose signatures are included in the block. The weight of a chain is the sum of the block weights.
 >
@@ -237,7 +237,7 @@ NEAR uses a gas-based model where prices are generally deterministically adjuste
 
 We avoid making changes that are too large through re-sharding by changing number of available shards (and thus throughput).
 
-Accounts don’t have associated resources. Gas amount is predetermined for all transactions except function calls. For function call transactions the user (or more likely the developer) attaches the required amount of gas. If some gas is left over after the function call, it is converted back to Near and refunded to the original funding account.
+Accounts don’t have associated resources. Gas amount is predetermined for all transactions except function calls. For function call transactions the user (or more likely the developer) attaches the required amount of gas. If some gas is left over after the function call, it is converted back to NEAR and refunded to the original funding account.
 
 ### How do we know how much gas to add to a transaction?
 

--- a/docs/tokens/token-custody.md
+++ b/docs/tokens/token-custody.md
@@ -116,12 +116,12 @@ You will be given the option to "Remove all other keys". Choosing "yes" means yo
   
   MathWallet also has a Chrome extension that supports NEAR, see section below.
   
-  ***Setup Near Account in MathWallet***
+  ***Setup NEAR Account in MathWallet***
   
 1. Install MathWallet on your phone from [https://mathwallet.org/](https://mathwallet.org/).
-2. Switch to 'Near' chain.
-3. Create/import a Near account.
-4. You will see your Near address to send/receive tokens.
+2. Switch to 'NEAR' chain.
+3. Create/import a NEAR account.
+4. You will see your NEAR address to send/receive tokens.
 
 ## Option 3: Moonlet Wallet
 
@@ -134,7 +134,7 @@ Add NEAR tokens to your main account and start staking to your favourite node.
 
 ***Support Pages:***
 
-- Check here for more about Near Staking within Moonlet: https://moonlet.io/near-staking/
+- Check here for more about NEAR Staking within Moonlet: https://moonlet.io/near-staking/
 - Check this page to learn more about Ledger connectivity: https://moonlet.io/moonlet-a-ledger-ready-hodl-wallet/
 
 

--- a/docs/tutorials/contracts/cross-contract-calls.md
+++ b/docs/tutorials/contracts/cross-contract-calls.md
@@ -71,7 +71,7 @@ We're interested in writing only one function for this example. A function that 
 import { context, storage, logging } from "near-sdk-as";
 
 export function addLongNumbers(a: string, b: string): string {
-  // sends logs to the terminal of the contract placing call and the Near Explorer
+  // sends logs to the terminal of the contract placing call and the NEAR Explorer
   logging.log("-------------------------------------------------------")
   logging.log('Contract Called : ' + context.contractName)
   logging.log('Contract Signer : ' + context.predecessor)
@@ -112,7 +112,7 @@ export function addLongNumbers(a: string, b: string): string {
   // Reverse again and combine the values for the final result
   let reversedResultArray = resultArray.reverse();
 
-  // More terminal / Near Explorer logs
+  // More terminal / NEAR Explorer logs
   logging.log(">>> RESULT : " + reversedResultArray.join(""))
   logging.log("-------------------------------------------------------")
   return reversedResultArray.join("");
@@ -450,7 +450,7 @@ Remember when we took a note that the 'Contract Called' and the 'Contract Signer
 
 And we're done!
 
-You can also view the details of your account & transactions by using the [Near Explorer](https://explorer.testnet.near.org/).
+You can also view the details of your account & transactions by using the [NEAR Explorer](https://explorer.testnet.near.org/).
 
 This is a simple example of a contract that calls another contract, but this opens up a lot of opportunities.
 

--- a/docs/tutorials/contracts/intro-to-rust.md
+++ b/docs/tutorials/contracts/intro-to-rust.md
@@ -54,7 +54,7 @@ We'll break down the code in pieces below. If you wish to preview the complete c
 [package]
 name = "rust-counter-tutorial"
 version = "0.1.0"
-authors = ["Near Inc <hello@near.org>"]
+authors = ["NEAR Inc <hello@near.org>"]
 edition = "2018"
 
 [lib]

--- a/docs/tutorials/rainbow-bridge-frontend.md
+++ b/docs/tutorials/rainbow-bridge-frontend.md
@@ -84,7 +84,7 @@ sidebar_label: Using Mainnet Frontend
 
 </center>
 
-> - Make sure the network selection option is set to Near-Ethereum.
+> - Make sure the network selection option is set to NEAR-Ethereum.
 
 <center>
 
@@ -114,7 +114,7 @@ sidebar_label: Using Mainnet Frontend
 
 <center>
 
-<img alt="Near Approval tool" src="https://i.imgur.com/2j3qa2f.png" width=50%/>
+<img alt="NEAR Approval tool" src="https://i.imgur.com/2j3qa2f.png" width=50%/>
 
 </center>
 

--- a/docs/tutorials/rainbow-frontend-dev-tutorial.md
+++ b/docs/tutorials/rainbow-frontend-dev-tutorial.md
@@ -160,7 +160,7 @@ sidebar_label: Using Testnet Frontend
 
 ---
 
-## Step 4 - Let's get Connected! (Near Wallet)
+## Step 4 - Let's get Connected! (NEAR Wallet)
 
 > - Good Job! Now let's move onto the next step, connecting your near wallet.
 
@@ -172,13 +172,13 @@ sidebar_label: Using Testnet Frontend
 
 </center>
 
-> - Select the connect button next to the Near Icon.
+> - Select the connect button next to the NEAR Icon.
 
 <center>
 
 <img alt="near wallet approval" src="https://i.imgur.com/qYsu2db.png" width="30%"/>
 
-(Fig 13 Near Wallet )
+(Fig 13 NEAR Wallet )
 
 </center>
 

--- a/docs/validator/staking-kr.md
+++ b/docs/validator/staking-kr.md
@@ -29,7 +29,7 @@ Wait until your node is fully synced before you send a staking transaction.
 |   https://rpc.testnet.near.org    |   https://rpc.betanet.near.org    |
 
 BetaNet은주간 Release를 위해 매주 화요일 오후 6시에 재설정됩니다. 검증인 상태를 잃는 것을 방지하기 위해 자동 업데이트를 활성화 하는 `nearup`을 사용하여 노드를 재시작해야 할 것입니다.
-최신 릴리즈가 언제 배포될 것인지 그리고 언제 당신의 노드를 안전하게 재시작할지를 알기 위해서 Near Protocol [validator channel on Telegram](https://t.me/near_validators) 이나 [Discord](https://discord.gg/ZMPr3VB) 에가입하세요.
+최신 릴리즈가 언제 배포될 것인지 그리고 언제 당신의 노드를 안전하게 재시작할지를 알기 위해서 NEAR Protocol [validator channel on Telegram](https://t.me/near_validators) 이나 [Discord](https://discord.gg/ZMPr3VB) 에가입하세요.
 
 ## 노드 요구사항
 
@@ -68,18 +68,18 @@ At least 50 GB free disk
       그렇지 않다면, 다음의 링크로 가서 설치를 진행하세요[node.js](https://nodejs.org/en/download/).
       노드는 주로 npm을 자동으로 설치한다는 것을 기억하세요. 그러나 만약 npm이 설치되지 않을 경우 [여기](https://www.npmjs.com/get-npm)에서 설치하세요.
 
-node와 npm이 설치되었다면 Near CLI 다운로드 받고 다음을 당신의 터미널에 입력하세요.
+node와 npm이 설치되었다면 NEAR CLI 다운로드 받고 다음을 당신의 터미널에 입력하세요.
 
 ```bash
-# npm으로 Near CLI 다운 받기:
+# npm으로 NEAR CLI 다운 받기:
 npm i -g near-cli
 ```
 
-Near CLIl이 설치되면, 노드를 실행하세요.
+NEAR CLIl이 설치되면, 노드를 실행하세요.
 
 ### 노드 실행
 
-이제 보유한 Near CLI 당신의 노드를 설정할 수 있습니다. 다음을 참조하세요[Nearup documentation](https://github.com/near/nearup).
+이제 보유한 NEAR CLI 당신의 노드를 설정할 수 있습니다. 다음을 참조하세요[Nearup documentation](https://github.com/near/nearup).
 
 ** 중요 이 부분에서 이전 단계에서 만들었단 당신의 계정의 이름인 계정 ID가 필요합니다. **
 
@@ -155,7 +155,7 @@ Legend: # 7153 | BlockHeight V/1 | 'V' (validator) or '—' (regular node)
 
 현재 검증인 리스트를 보기 위해서 다음을 참조하세요:[https://rpc.betanet.near.org/status](https://rpc.betanet.near.org/status)
 
-만약 검증자가 얼마나 스테이킹을 하고 있는지 보기 위해서, 당신은 `near state <account name>` 명령어를 Near CLI에서 수행할 수 있습니다.
+만약 검증자가 얼마나 스테이킹을 하고 있는지 보기 위해서, 당신은 `near state <account name>` 명령어를 NEAR CLI에서 수행할 수 있습니다.
 
 ```bash
 {

--- a/docs/validator/staking.md
+++ b/docs/validator/staking.md
@@ -59,16 +59,16 @@ More information is on the [Hardware Requirements](/docs/develop/node/validator/
 
 **IMPORTANT: Make sure you have the latest version of [NEAR CLI](https://github.com/near/near-cli) and Node Version 12.x**
 
-You can instal and upgrade Near CLI by using npm:
+You can instal and upgrade NEAR CLI by using npm:
 
 ```bash
-# Download Near CLI with npm:
+# Download NEAR CLI with npm:
 npm i -g near-cli
 ```
 
 **Note:** The default network for `near-cli` is `testnet`. If you would like to change this to `mainnet` or `betanet`, please see [`near-cli` network selection](/docs/tools/near-cli#network-selection) for instructions.
 
-Once Near CLI is installed, go ahead and run your node.
+Once NEAR CLI is installed, go ahead and run your node.
 
 <blockquote class="info">
     <strong>Pro Tip</strong><br><br>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -41,7 +41,7 @@ const siteConfig = {
   },
 
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
-  copyright: `Copyright © ${new Date().getFullYear()} Near Protocol`,
+  copyright: `Copyright © ${new Date().getFullYear()} NEAR Protocol`,
 
   highlight: {
     // Highlight.js theme to use for syntax highlighting in code blocks.


### PR DESCRIPTION
Fixes #835 
- Near Inc --> NEAR Inc
- Near --> NEAR
- Near Foundation --> NEAR Foundation
- Near Team --> NEAR Team
- Near Protocol --> NEAR Protocol
- Near Account --> NEAR Account
- Near chain --> NEAR chain
- Near address --> NEAR address
- Near Staking --> NEAR Staking
- Near Explorer --> NEAR Explorer
- Near-Ethereum --> NEAR-Ethereum
- Near Approval tool --> NEAR Approval tool
- Near Wallet --> NEAR Wallet
- Near Icon --> NEAR Icon
- Near CLI --> NEAR CLI