### PR TITLE
Add Developer FAQ to the sidebar navigation

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -21,7 +21,8 @@
     "Basics": [
       "develop/basics/getting-started",
       "develop/basics/create-account",
-      "develop/basics/hackathon-startup-guide"
+      "develop/basics/hackathon-startup-guide",
+      "faq/developer-faq"
     ],
     "Tools": [
       "tools/near-wallet",


### PR DESCRIPTION
This PR adds an orphan `Developer FAQ` to the site navigation.