### PR TITLE
link to near-sdk.io site in the Rust SDK section

### DIFF
--- a/docs/develop/contracts/rust/near-sdk-rs.md
+++ b/docs/develop/contracts/rust/near-sdk-rs.md
@@ -1,8 +1,14 @@
 ---
 id: near-sdk-rs
-title: near-sdk
+title: Rust SDK for smart contracts
 sidebar_label: Rust SDK
 ---
+
+It's recommended to visit the SDK Docs site for a detailed explanation of the Rust SDK.
+
+https://near-sdk.io
+
+Also, you may visit the reference material at:
 
 https://docs.rs/near-sdk
 


### PR DESCRIPTION
This effort is to provide a link to the SDK Docs site so that search engines can begin indexing this site. While it's in good shape, we cannot consider it fully complete at this time. When that time comes, we can discuss reworking other parts of this page in docs.