### PR TITLE
Fix parameter error exchange-integration.md

### DIFF
--- a/docs/roles/integrator/exchange-integration.md
+++ b/docs/roles/integrator/exchange-integration.md
@@ -1011,7 +1011,7 @@ Get storage balance of the account. `storage_balance_of` function returns the am
          "finality": "final",
          "account_id": "ft.demo.testnet",
          "method_name": "storage_balance_of",
-         "eyJhY2NvdW50X2lkIjogInNlcmhpaS50ZXN0bmV0In0K"
+         "args_base64": "eyJhY2NvdW50X2lkIjogInNlcmhpaS50ZXN0bmV0In0K"
       }'
       ```
 


### PR DESCRIPTION
As reported by developer, the `args_base64` key is missing. 