### PR TITLE
Fixed formatting of payable notice

### DIFF
--- a/docs/develop/contracts/rust/near-sdk-rs.md
+++ b/docs/develop/contracts/rust/near-sdk-rs.md
@@ -152,7 +152,7 @@ pub fn my_method(&mut self) {
 }
 ```
 
-> The `#[payable]` macro works only inside the struct wrapped in `#[near_bindgen]`, if you put it elsewhere, you will get a `cannot find attribute `payable` in this scope` error.
+> The `#[payable]` macro works only inside the struct wrapped in `#[near_bindgen]`, if you put it elsewhere, you will get a `cannot find attribute 'payable' in this scope` error.
 
 ## Pre-requisites
 To develop Rust contracts you would need to:


### PR DESCRIPTION
@thisisjoshford A follow up of #844, I realized there was backticks inside an already backticked sentence, changed the inner one to `'`