### PR TITLE
Fix init command

### DIFF
--- a/docs/develop/node/archival/run-archival-node-without-nearup.md
+++ b/docs/develop/node/archival/run-archival-node-without-nearup.md
@@ -93,7 +93,7 @@ In order to work properly, the NEAR node requires a working directory and a coup
 Generate the initial required working directory by running:
 
 ```bash
-$ ./target/release/neard --home ~/.near init --chain-id testnet --download
+$ ./target/release/neard --home ~/.near init --chain-id testnet --download-genesis --download-config
 ```
 
 > You can skip the `--home` argument if you are fine with the default working directory in `~/.near`. If not, pass your preferred location.
@@ -222,7 +222,7 @@ In order to work NEAR node requires to have working directory and a couple of co
 Generate the initial required working directory by running:
 
 ```bash
-$ ./target/release/neard --home ~/.near init --chain-id mainnet --download
+$ ./target/release/neard --home ~/.near init --chain-id mainnet --download-genesis --download-config
 ```
 
 > You can skip the `--home` argument if you are fine with the default working directory in `~/.near`. If not, pass your preferred location.


### PR DESCRIPTION
I guess "download" flag existed at some point, but from what I see it is separated into two different flags. 

The logic of downloading JSON data itself is not very clear, but I think it is safe to enable both flags `--download-genesis --download-config` here.