### PR TITLE
fixed node singular in title to "nodes" plural for "types of nodes"

### DIFF
--- a/docs/develop/node/intro/types-of-node.md
+++ b/docs/develop/node/intro/types-of-node.md
@@ -1,23 +1,26 @@
 ---
-id: types-of-node
-title: Types of Node
-sidebar_label: Types of Node
-description: Types of NEAR Node
+id: types-of-nodes
+title: Types of Nodes
+sidebar_label: Types of Nodes
+description: Types of NEAR Nodes
 ---
 
 You can run three different types of node - Validator Node, RPC Node, and Archival Node.
 
 ### Validator Node
+
 Validator nodes are the operators of the NEAR blockchain and are essential to the health of the network. Validator nodes participate in the consensus and produce blocks and/or chunks. You can see a real-time view of NEAR network validator nodes on the [NEAR Explorer](https://explorer.near.org/nodes/validators).
 
 ### RPC Node
+
 RPC nodes are RPC service providers that provide public RPC endpoints for developers to use. The NEAR Foundation currently maintains a public RPC endpoint `http://rpc.mainnet.near.org/` that is free for everyone to use. However, any participants are encouraged to run their own RPC node and offer RPC services through [an Open Source & Public Goods grant from the NEAR Foundation](https://near.org/grants/). For more information, please check out Community section in the documentation and reach out in the Validator Channels on [Discord](https://discord.gg/ZMPr3VB) and on [Telegram](https://t.me/near_validators).
 
 ### Archival Node
+
 Archival nodes store full blockchain data, and build an archive of historical states. These nodes are useful for block explorers, chain analysis, and infrastructure providers.
 
 See [API Setup](/docs/api/rpc#setup) section for archival RPC nodes endpoints.
 
->Got a question?
-<a href="https://stackoverflow.com/questions/tagged/nearprotocol">
-  <h8>Ask it on StackOverflow!</h8></a>
+> Got a question?
+> <a href="https://stackoverflow.com/questions/tagged/nearprotocol">
+> <h8>Ask it on StackOverflow!</h8></a>


### PR DESCRIPTION
Fixed small typo in title of page "types of node" to "types of nodes" 