### PR TITLE
remove near-apps org

### DIFF
--- a/docs/api/javascript-library.md
+++ b/docs/api/javascript-library.md
@@ -11,6 +11,5 @@ sidebar_label: JavaScript Library
 | [Cheatsheet / Quick Reference](/docs/api/naj-quick-reference) | Quick easy way to get started with the most common uses of `near-api-js`. |
 | [Cookbook](/docs/api/naj-cookbook)                            | Common use case scenarios for `near-api-js`.                              |
 | [TypeDocs](https://near.github.io/near-api-js/)               | Documentation created from the codebase itself.                           |
-| [Boilerplate Code](https://github.com/near-apps/nearbp)       | Boilerplate example code                                                  |
 | [Examples](https://examples.near.org/)                        | Example applications using `near-api-js`                                  |
 | [GH Repository](https://github.com/near/near-api-js/)         | Link to `near-api-js` on GitHub.                                          |

--- a/docs/develop/basics/getting-started.md
+++ b/docs/develop/basics/getting-started.md
@@ -19,7 +19,6 @@ sidebar_label: Getting Started
 | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
 | **Example Projects**                                   |                                                                                                          |
 | **[NEAR Examples](https://near.dev)**                  | Basic example apps built on NEAR that you can clone and explore.                                         |
-| **[NEAR Apps](https://github.com/near-apps)**          | More advanced example apps built on NEAR that showcase functionality.                                    |
 | **Tools**                                              |                                                                                                          |
 | **[NEAR Wallet](/docs/tools/near-wallet)**             | Create and manage [accounts](/docs/concepts/account) & [access keys](/docs/concepts/account#access-keys) |
 | **[NEAR Explorer](/docs/tools/near-explorer)**         | View and inspect [transactions](/docs/concepts/transaction) taking place on the blockchain               |

--- a/docs/develop/basics/hackathon-guide.md
+++ b/docs/develop/basics/hackathon-guide.md
@@ -134,10 +134,6 @@ under your HOME folder (`~/.near-credentials`)_
 4) Head to [NEAR Examples](https://near.dev) and test out some example applications. You can clone and play
 around with the code or simply click on the Gitpod button to launch an online instance!
 
-6) Ready to dive in? Checkout some more [boilerplate apps](#boilerplate-apps) with accompanying video
-walkthroughs [ [here](https://github.com/near-apps/) ].
-
-
 ## Understanding Smart Contracts
 
 Smart Contracts are the back-end of your application, which lives on the blockchain. The application still needs the same front-end stuff (HTML/CSS/JS) you're used to, but all of your data, or "state," will be stored _on-chain_.

--- a/docs/develop/front-end/near-api-js.md
+++ b/docs/develop/front-end/near-api-js.md
@@ -11,6 +11,5 @@ sidebar_label: Overview
 | [Cheatsheet / Quick Reference](/docs/api/naj-quick-reference) | Quick easy way to get started with the most common uses of `near-api-js`. |
 | [Cookbook](/docs/api/naj-cookbook)                            | Common use case scenarios for `near-api-js`.                              |
 | [TypeDocs](https://near.github.io/near-api-js/)               | Documentation created from the codebase itself.                           |
-| [Boilerplate Code](https://github.com/near-apps/nearbp)       | Boilerplate example code                                                  |
 | [Examples](https://examples.near.org/)                        | Example applications using `near-api-js`                                  |
 | [GH Repository](https://github.com/near/near-api-js/)         | Link to `near-api-js` on GitHub.                                          |

--- a/docs/tutorials/contracts/guest-book.md
+++ b/docs/tutorials/contracts/guest-book.md
@@ -988,7 +988,7 @@ Pat yourself on the back. You not only delved a bit deeper into writing smart co
   [jest]: https://jestjs.io/
   [NEAR accounts]: /docs/concepts/account
   [NEAR Wallet]: https://wallet.near.org
-  [Near App examples]: https://github.com/near-apps
+  [Near App examples]: https://near.dev
   [near-cli]: https://github.com/near/near-cli
   [CLI]: https://www.w3schools.com/whatis/whatis_cli.asp
   [create-near-app]: https://github.com/near/create-near-app


### PR DESCRIPTION
`near-apps` org is being archived as many examples do not follow NEP standards which is creating some confusion amongst our developer community. This PR removes pointers to that org aside from the youtube links to the "Live App Review" Series. This will be resolved in another ticket.