### PR TITLE
replaced markdown newlines with html newlines

### DIFF
--- a/docs/concepts/architecture/papers.md
+++ b/docs/concepts/architecture/papers.md
@@ -15,7 +15,7 @@ Join us as we dive deep into our technology.
 [Sharding Design: Nightshade](https://near.org/papers/nightshade/)<br/>
 *This document outlines the general approach to blockchain sharding, the major problems that need to be overcome, including state validity and data availability problems, and presents Nightshade, the solution NEAR Protocol is built upon that addresses those issues.*
 
-[Fast Finality: Proof of Space-Time](https://near.org/papers/proof-of-space-time/)<br>
+[Fast Finality: Proof of Space-Time](https://near.org/papers/proof-of-space-time/)<br/>
 *We present a design for a fork choice rule, Sybil resistance mechanism and finality gadget that collectively provide fast finality, resistance to long range attacks, and discourage pooling. The design is based on both proof of stake and proof of space time, and uses a finality gadget similar to Casper FFG.*
 
 [NEAR Randomness](https://near.org/papers/randomness/)<br>

--- a/docs/concepts/architecture/papers.md
+++ b/docs/concepts/architecture/papers.md
@@ -9,7 +9,7 @@ Join us as we dive deep into our technology.
 [The NEAR White Paper](https://near.org/papers/the-official-near-white-paper/)<br/>
 *This document describes the approach NEAR takes to designing and implementing the core technology of its system.*
 
-[Economics in a Sharded Blockchain](https://near.org/papers/economics-in-sharded-blockchain/)<br>
+[Economics in a Sharded Blockchain](https://near.org/papers/economics-in-sharded-blockchain/)<br/>
 *Incentives are a crucial part of any decentralized protocol. In this paper, we review the specific economic decisions that must be made, and the logic behind them.*
 
 [Sharding Design: Nightshade](https://near.org/papers/nightshade/)<br>

--- a/docs/concepts/architecture/papers.md
+++ b/docs/concepts/architecture/papers.md
@@ -6,7 +6,7 @@ sidebar_label: Papers
 
 Join us as we dive deep into our technology.
 
-[The NEAR White Paper](https://near.org/papers/the-official-near-white-paper/)<br>
+[The NEAR White Paper](https://near.org/papers/the-official-near-white-paper/)<br/>
 *This document describes the approach NEAR takes to designing and implementing the core technology of its system.*
 
 [Economics in a Sharded Blockchain](https://near.org/papers/economics-in-sharded-blockchain/)<br>

--- a/docs/concepts/architecture/papers.md
+++ b/docs/concepts/architecture/papers.md
@@ -18,5 +18,5 @@ Join us as we dive deep into our technology.
 [Fast Finality: Proof of Space-Time](https://near.org/papers/proof-of-space-time/)<br/>
 *We present a design for a fork choice rule, Sybil resistance mechanism and finality gadget that collectively provide fast finality, resistance to long range attacks, and discourage pooling. The design is based on both proof of stake and proof of space time, and uses a finality gadget similar to Casper FFG.*
 
-[NEAR Randomness](https://near.org/papers/randomness/)<br>
+[NEAR Randomness](https://near.org/papers/randomness/)<br/>
 *We present a randomness beacon scheme that is unpredictable and unbiasable for as long as more than 1/3 of participants follow the protocol, is live for as long as 2/3 of participants follow the protocol, doesn’t depend on verifiable delay functions and doesn’t require distributed key generation.*

--- a/docs/concepts/architecture/papers.md
+++ b/docs/concepts/architecture/papers.md
@@ -6,17 +6,17 @@ sidebar_label: Papers
 
 Join us as we dive deep into our technology.
 
-[The NEAR White Paper](https://near.org/papers/the-official-near-white-paper/)  \
+[The NEAR White Paper](https://near.org/papers/the-official-near-white-paper/)<br>
 *This document describes the approach NEAR takes to designing and implementing the core technology of its system.*
 
-[Economics in a Sharded Blockchain](https://near.org/papers/economics-in-sharded-blockchain/)  \
+[Economics in a Sharded Blockchain](https://near.org/papers/economics-in-sharded-blockchain/)<br>
 *Incentives are a crucial part of any decentralized protocol. In this paper, we review the specific economic decisions that must be made, and the logic behind them.*
 
-[Sharding Design: Nightshade](https://near.org/papers/nightshade/)  \
+[Sharding Design: Nightshade](https://near.org/papers/nightshade/)<br>
 *This document outlines the general approach to blockchain sharding, the major problems that need to be overcome, including state validity and data availability problems, and presents Nightshade, the solution NEAR Protocol is built upon that addresses those issues.*
 
-[Fast Finality: Proof of Space-Time](https://near.org/papers/proof-of-space-time/)  \
+[Fast Finality: Proof of Space-Time](https://near.org/papers/proof-of-space-time/)<br>
 *We present a design for a fork choice rule, Sybil resistance mechanism and finality gadget that collectively provide fast finality, resistance to long range attacks, and discourage pooling. The design is based on both proof of stake and proof of space time, and uses a finality gadget similar to Casper FFG.*
 
-[NEAR Randomness](https://near.org/papers/randomness/)  \
+[NEAR Randomness](https://near.org/papers/randomness/)<br>
 *We present a randomness beacon scheme that is unpredictable and unbiasable for as long as more than 1/3 of participants follow the protocol, is live for as long as 2/3 of participants follow the protocol, doesn’t depend on verifiable delay functions and doesn’t require distributed key generation.*

--- a/docs/concepts/architecture/papers.md
+++ b/docs/concepts/architecture/papers.md
@@ -12,7 +12,7 @@ Join us as we dive deep into our technology.
 [Economics in a Sharded Blockchain](https://near.org/papers/economics-in-sharded-blockchain/)<br/>
 *Incentives are a crucial part of any decentralized protocol. In this paper, we review the specific economic decisions that must be made, and the logic behind them.*
 
-[Sharding Design: Nightshade](https://near.org/papers/nightshade/)<br>
+[Sharding Design: Nightshade](https://near.org/papers/nightshade/)<br/>
 *This document outlines the general approach to blockchain sharding, the major problems that need to be overcome, including state validity and data availability problems, and presents Nightshade, the solution NEAR Protocol is built upon that addresses those issues.*
 
 [Fast Finality: Proof of Space-Time](https://near.org/papers/proof-of-space-time/)<br>


### PR DESCRIPTION
just a formatting issue to remove some markdown newlines (`\  ` <-- a backslash followed by two spaces) since someone editing this repo is clipping those spaces at the end of their lines with a listing tool most likely