### PR TITLE
Change pinned versions of docs.rs links to use "latest"

### DIFF
--- a/docs/concepts/data-collections.md
+++ b/docs/concepts/data-collections.md
@@ -194,7 +194,7 @@ map.getSome(key)
 
 ## Rust Collection Types
 
-[`near-sdk-rs` module documentation](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/)
+[`near-sdk-rs` module documentation](https://docs.rs/near-sdk/latest/near_sdk/collections/)
 
 | Type                                                       | Iterable | Clear All Values | Preserves Insertion Order | Range Selection |
 | ---------------------------------------------------------- | :------: | :--------------: | :-----------------------: | :-------------: |
@@ -252,7 +252,7 @@ map.getSome(key)
 
 [ [SDK source](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/vector.rs) ]
 
-[ [Implementation](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/struct.Vector.html) ]
+[ [Implementation](https://docs.rs/near-sdk/latest/near_sdk/collections/struct.Vector.html) ]
 
 ---
 
@@ -265,7 +265,7 @@ map.getSome(key)
 
 [ [SDK source](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/lookup_set.rs) ]
 
-[ [Implementation](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/struct.LookupSet.html) ]
+[ [Implementation](https://docs.rs/near-sdk/latest/near_sdk/collections/struct.LookupSet.html) ]
 
 ---
 
@@ -275,7 +275,7 @@ map.getSome(key)
 
 [ [SDK source](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/unordered_set.rs) ]
 
-[ [Implementation Docs](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/struct.UnorderedSet.html) ]
+[ [Implementation Docs](https://docs.rs/near-sdk/latest/near_sdk/collections/struct.UnorderedSet.html) ]
 
 ---
 
@@ -312,7 +312,7 @@ pub fn get_lookup_map(&self, key: String) -> String {
 
 [ [SDK source](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/lookup_map.rs) ]
 
-[ [Implementation](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/struct.LookupMap.html) ]
+[ [Implementation](https://docs.rs/near-sdk/latest/near_sdk/collections/struct.LookupMap.html) ]
 
 ---
 
@@ -350,7 +350,7 @@ pub fn get_unordered_map(&self, key: String) -> String {
 
 [ [SDK source](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/unordered_map.rs) ]
 
-[ [Implementation](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/struct.UnorderedMap.html) ]
+[ [Implementation](https://docs.rs/near-sdk/latest/near_sdk/collections/struct.UnorderedMap.html) ]
 
 ---
 
@@ -391,4 +391,4 @@ pub fn get_tree_map(&self, key: String) -> String {
 
 [ [SDK source](https://github.com/near/near-sdk-rs/blob/master/near-sdk/src/collections/tree_map.rs) ]
 
-[ [Implementation](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/struct.TreeMap.html) ]
+[ [Implementation](https://docs.rs/near-sdk/latest/near_sdk/collections/struct.TreeMap.html) ]

--- a/docs/tutorials/contracts/xcc-rust.md
+++ b/docs/tutorials/contracts/xcc-rust.md
@@ -57,7 +57,7 @@ pub fn my_method(&self) {
 
 ## Mid Level
 
-`near-sdk-rs` provides some intermediate syntax that can help abstract away from all the low level Promise Bindings ([SDK Promise Documentation](https://docs.rs/near-sdk/3.1.0/near_sdk/struct.Promise.html)). Internally `env::promise_batch_create` and `env::promise_batch_then` are still being used ([code here](https://github.com/near/near-sdk-rs/blob/0507deb84da77d83833a4db2563b76e8fe5d0b12/near-sdk/src/promise.rs#L112)).
+`near-sdk-rs` provides some intermediate syntax that can help abstract away from all the low level Promise Bindings ([SDK Promise Documentation](https://docs.rs/near-sdk/latest/near_sdk/struct.Promise.html)). Internally `env::promise_batch_create` and `env::promise_batch_then` are still being used ([code here](https://github.com/near/near-sdk-rs/blob/0507deb84da77d83833a4db2563b76e8fe5d0b12/near-sdk/src/promise.rs#L112)).
 
 ```rust
 pub fn my_method(&self) -> Promise {

--- a/docs/videos/collections-u128-etc.md
+++ b/docs/videos/collections-u128-etc.md
@@ -28,9 +28,9 @@ This page contains videos that explore miscellaneous concepts of smart contract 
   allowfullscreen>
 </iframe>
 
-Here we address [this question](https://stackoverflow.com/questions/64378144/why-cant-i-read-this-hashmap-in-a-near-contract/64438703#64438703) on StackOverflow and specifically, we'll talk about why you'll likely want to use NEAR Collections instead of `HashMap` when using Rust. See a list of the available collections [here](https://docs.rs/near-sdk/2.0.0/near_sdk/collections/index.html). In this video we discuss:
+Here we address [this question](https://stackoverflow.com/questions/64378144/why-cant-i-read-this-hashmap-in-a-near-contract/64438703#64438703) on StackOverflow and specifically, we'll talk about why you'll likely want to use NEAR Collections instead of `HashMap` when using Rust. See a list of the available collections [here](https://docs.rs/near-sdk/latest/near_sdk/collections/index.html). In this video we discuss:
 
-- [`U128`](https://docs.rs/near-sdk/2.0.0/near_sdk/json_types/struct.U128.html) and the difference between the (lowercase) `u128`
+- [`U128`](https://docs.rs/near-sdk/latest/near_sdk/json_types/struct.U128.html) and the difference between the (lowercase) `u128`
 - why JSON cannot handle very large numbers
 - how to interact with a Rust smart contract using NEAR CLI
 - demonstrate logging, `view` and `call` methods, and unit tests 


### PR DESCRIPTION
Self-explanatory, we want folks to see links to the latest version of the Rust docs.