### PR TITLE
adding a nearbindgen description to docs

### DIFF
--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -166,6 +166,8 @@ export class TextMessage {
 // see https://github.com/near/near-sdk-as/blob/master/assembly/__tests__/runtime/model.ts
 ```
 
+`@nearBindgen` is a decorator made for the serialization of custom classes before they are saved to storage onto the blockchain
+
 #### Models are composable {#models-are-composable}
 
 Models can build on top of one another as with the sample below, taken from [CryptoCorgis](https://github.com/nearprotocol/corgis), which includes 3 models:
@@ -706,5 +708,4 @@ export function myPublicFunction(someInput: string): void {
 ```
 
 > Got a question?
-> <a href="https://stackoverflow.com/questions/tagged/nearprotocol">
-> <h8>Ask it on StackOverflow!</h8></a>
+> <a href="https://stackoverflow.com/questions/tagged/nearprotocol"> > <h8>Ask it on StackOverflow!</h8></a>


### PR DESCRIPTION
In the assemblyscript intro doc. It shows the use of nearbindgen without a proper description as to what it's for. So wanted to add a note of what it is and why you need to include it. 