### PR TITLE
remove create-near-app mentions

### DIFF
--- a/docs/develop/basics/getting-started.md
+++ b/docs/develop/basics/getting-started.md
@@ -43,22 +43,3 @@ sidebar_label: Getting Started
 
 **[ [This workshop](https://bit.ly/near-102) ]** is designed for Ethereum developers looking to get started developing on NEAR. _( 60 min )_
 
----
-
-## CREATE-NEAR-APP {#create-near-app}
-
-> With [`create-near-app`](https://github.com/near/create-near-app), you can launch a full-stack "Hello World" app in under five minutes! Try it out by running the following in your terminal _(Requires [Node.js](https://nodejs.org/en/))_:
-
-```bash
-npx create-near-app your-awesome-project
-```
-
-<blockquote class="warning">
-<strong>Heads Up!</strong><br /><br />
-
-The command above defaults to a Vanilla JavaScript front-end and an [AssemblyScript](https://www.assemblyscript.org/) smart contract. You can also choose to use [React](https://reactjs.org/) for your front end and/or [Rust](https://www.rust-lang.org/) for your smart contract.
-
-- `--frontend=react` – to use React for your front end template
-- `--contract=rust` – to use Rust for your smart contract
-
-</blockquote>

--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -21,7 +21,7 @@ AssemblyScript smart contract development is for non financial use cases.
 
 ## Quickstart {#quickstart}
 
-- You may use [`create-near-app`](https://github.com/near/create-near-app) to get started locally or explore [examples](http://near.dev/) to work online in gitpod online IDE.
+- Explore [examples](http://near.dev/) to work online in gitpod online IDE.
 - You write contracts in [AssemblyScript](https://assemblyscript.org/introduction.html) and use `near-sdk-as` to interact with the blockchain (storage, context, etc)
 - The AssemblyScript is compiled to [Wasm](https://learnxinyminutes.com/docs/wasm/) and (using either NEAR CLI, `near-api-js` or our RPC interface) it is deployed to an account on the NEAR platform
 - When a method on the contract is invoked, NEAR routes the request to the proper shard (the one with the account that "holds" or "owns" the contract, see [more about accounts here](/docs/concepts/account))
@@ -57,7 +57,7 @@ From within this contract method you can also access the blockchain execution co
 
 ### File Structure {#file-structure}
 
-The fastest way to get started locally is to use [`create-near-app`](https://github.com/near/create-near-app) from your terminal or explore [examples](http://near.dev/) if you would rather work online. Regardless of which of these environments you choose, the development and build process is similar.
+The fastest way to get started locally is to clone one of our [examples](http://near.dev/) or interact with them immediately using Gitpod (an online IDE).
 
 Contracts have [all of the features of AssemblyScript](https://assemblyscript.org/introduction.html) at their disposal and contract files end with `.ts` since AssemblyScript is a dialect of TypeScript.
 
@@ -112,11 +112,11 @@ For more on AssemblyScript, consider the small AssemblyScript examples included 
 
 ## Development {#development}
 
-If you choose to use `create-near-app`, we provide a set of helpful scripts in the `package.json` file that handle building and deployment as well as some useful local development automation.
+In most of our examples on [near.dev](http://near.dev), we provide a set of helpful scripts in the `package.json` file that handle building and deployment as well as some useful local development automation.
 
 You can run `npm run dev` to start working with the provided sample and `npm run start` to deploy the example (using a temporary dev account) to TestNet.
 
-See the full list of scripts in `create-near-app`'s `package.json`:
+See the full list of scripts in the `package.json`:
 
 ```json
 {

--- a/docs/develop/contracts/overview.md
+++ b/docs/develop/contracts/overview.md
@@ -18,8 +18,7 @@ If you're familiar with **Rust** then check out <code>[near-sdk-rs](/docs/develo
 
 If you prefer JavaScript then **AssemblyScript** is the way to go for writing Smart Contracts on the NEAR platform. 
 
-You can explore a lot of Smart Contract examples and deploy them in seconds, literally, from our [examples](http://near.dev). And if you'd rather build locally, check out [create-near-app](https://github.com/near/create-near-app) to get started.  Either way, you'll be interacting with your first deployed contract in minutes.
-
+You can explore a lot of Smart Contract examples and deploy them in seconds, literally, from our [examples](http://near.dev).
 
 <blockquote class="warning">
 <strong>heads up</strong><br /><br />

--- a/docs/develop/contracts/rust/intro.md
+++ b/docs/develop/contracts/rust/intro.md
@@ -679,20 +679,7 @@ This example is as bare bones as it gets, but illustrates all the moving parts a
 with writing a smart contract with Rust. Admittedly, it's a poor example when it comes to
 creating anything user-facing.
 
-Now that you're familiar with the build process, a natural next step is to check out
-`create-near-app`. This project includes another Rust smart contract but has an interface.
-With `create-near-app` many of the steps we performed on the command line are wrapped
-neatly into build scripts.
-
-[Read more](https://github.com/near/create-near-app/) about `create-near-app` or try it
-out now by running:
-
-```bash
-npx create-near-app --contract=rust new-awesome-app
-```
-
-Follow the instructions to set up a simple Rust smart contract with a React front-end.
-Happy coding!
+Now that you're familiar with the build process, a natural next step is to check out some of our examples at [near.dev](https://near.dev) and look for the `rust` label on the project.
 
 ## Versioning for this article {#versioning-for-this-article}
 

--- a/docs/develop/contracts/rust/testing.md
+++ b/docs/develop/contracts/rust/testing.md
@@ -152,7 +152,7 @@ As you can see there are two main components.
 
 **Note**: For more information on getting started, be sure to check out the [Jest Docs](https://jestjs.io/docs/en/getting-started).
 
-If you are starting a new project using [create-near-app](https://github.com/near/create-near-app) Jest will be automatically installed as a development dependency and will be configured to run end-to-end tests. If you explore the `package.json` file you will see that the `"testEnvironment"` for Jest is set to `"near-cli/test_environment"`. In addition to this, there is a file `test.near.json` in the `neardev/shared-test` directory. This file contains an `account_id` as well as a `private_key` that is required for performing these tests.
+If you are starting a new project using an example from [near.dev](http://near.dev) Jest should be automatically installed as a development dependency and will be configured to run end-to-end tests. If you explore the `package.json` file you will see that the `"testEnvironment"` for Jest is set to `"near-cli/test_environment"`. In addition to this, there is a file `test.near.json` in the `neardev/shared-test` directory. This file contains an `account_id` as well as a `private_key` that is required for performing these tests.
 
 Lets take a look at an example of end-to-end tests from the [NEAR Guest-Book](https://examples.near.org/guest-book) example. Here we have included two additional features to our tests.
   1) declaring mutable variables before a test that all subsequent tests have access to

--- a/docs/develop/front-end/introduction.md
+++ b/docs/develop/front-end/introduction.md
@@ -141,7 +141,7 @@ Whichever language you use to build your Smart Contracts, know that, once compil
 
 If you're familiar with JavaScript then **AssemblyScript** is the way to go for writing Smart Contracts on the NEAR platform.
 
-You can explore our [examples](http://near.dev) online and deploy your first Smart Contract in seconds, literally, with gitpod IDE. And if you'd rather build locally, check out [create-near-app](https://github.com/near/create-near-app) to get started. Either way, you'll be interacting with your first deployed contract in minutes.
+You can explore our [examples](http://near.dev) online and deploy your first Smart Contract in seconds, literally, with gitpod IDE.
 
 If you prefer **Rust** then check out <code>[near-sdk-rs](/docs/develop/contracts/rust/intro)</code> for authoring Smart Contracts in Rust that can be deployed using `near-api-js`. The `near-sdk-rs` repository has several great examples to help you get started quickly.
 

--- a/docs/tutorials/contracts/guest-book.md
+++ b/docs/tutorials/contracts/guest-book.md
@@ -991,7 +991,5 @@ Pat yourself on the back. You not only delved a bit deeper into writing smart co
   [Near App examples]: https://near.dev
   [near-cli]: https://github.com/near/near-cli
   [CLI]: https://www.w3schools.com/whatis/whatis_cli.asp
-  [create-near-app]: https://github.com/near/create-near-app
   [gh-pages]: https://github.com/tschaub/gh-pages
-  [create-near-app]: https://www.npmjs.com/package/create-near-app
   [figment.io]: https://learn.figment.io/tutorials/create-a-near-account

--- a/docs/tutorials/contracts/intro-to-rust.md
+++ b/docs/tutorials/contracts/intro-to-rust.md
@@ -680,19 +680,7 @@ with writing a smart contract with Rust. Admittedly, it's a poor example when it
 creating anything user-facing.
 
 Now that you're familiar with the build process, a natural next step is to check out
-`create-near-app`. This project includes another Rust smart contract but has an interface.
-With `create-near-app` many of the steps we performed on the command line are wrapped
-neatly into build scripts.
-
-[Read more](https://github.com/near/create-near-app/) about `create-near-app` or try it
-out now by running:
-
-```bash
-npx create-near-app --contract=rust new-awesome-app
-```
-
-Follow the instructions to set up a simple Rust smart contract with a React front-end.
-Happy coding!
+the examples from [near.dev](https://near.dev) and look for the `rust` label.
 
 ## Versioning for this article {#versioning-for-this-article}
 

--- a/website/tests/testcli.sh
+++ b/website/tests/testcli.sh
@@ -2,11 +2,3 @@
 npm install -g near-cli
 
 NODE_ENV=ci near state test.near
-
-
-# test app with snippets 
-npx create-near-app assemblyscript-vanilla
-cd assemblyscript-react
-#yarn TODO: investigate why this fails on build
-
-


### PR DESCRIPTION
We have migrated away from promoting `create-near-app` from the homepage and should have removed it from docs as well. This PR removes mentions of CRA and replaces them with references to examples found at near.dev. A newer version of CRA will be incorporated with the new dev-dashboard.