### PR TITLE
Reword the CPU requirements

### DIFF
--- a/docs/develop/node/validator/hardware.md
+++ b/docs/develop/node/validator/hardware.md
@@ -12,23 +12,35 @@ This page covers the minimum and recommended hardware requirements for engaging 
 
 | Hardware       |  Recommended Specifications                                                  |
 | -------------- | ---------------------------------------------------------------              |
-| CPU            | 8-Core (16-Thread) Intel i7/Xeon or equivalent with AVX support              |
+| CPU            | x86_64 (Intel, AMD) processor with at least 8 physical cores                 |
+| CPU Features   | CMPXCHG16B, POPCNT, SSE4.2, AVX                                              |
 | RAM            | 16GB DDR4                                                                    |
 | Storage        | 250GB SSD (NVMe SSD is recommended. HDD will be enough for localnet only)    |
 
-_Verify AVX support on Linux by issuing the command ```$ lscpu | grep -oh  avx```. If the output is empty, your CPU is not supported._
+Verify CPU feature support by running the following command on Linux:
 
+```
+lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )' > /dev/null \
+  && echo "Supported" \
+  || echo "Not supported"
+```
 
 ## Minimal Hardware Specifications {#minimal-hardware-specifications}
 
 | Hardware       |  Minimal Specifications                                                     |
 | -------------- | ---------------------------------------------------------------             |
-| CPU            | 8-Core (16-Thread) Intel i7/Xeon or equivalent with AVX support             |
+| CPU            | x86_64 (Intel, AMD) processor with at least 8 physical cores                |
+| CPU Features   | CMPXCHG16B, POPCNT, SSE4.2, AVX                                             |
 | RAM            | 8GB DDR4                                                                    |
 | Storage        | 250GB SSD (NVMe SSD is recommended. HDD will be enough for localnet only)   |
 
-_Verify AVX support on Linux by issuing the command ```$ lscpu | grep -oh  avx```. If the output is empty, your CPU is not supported._
+Verify CPU feature support by running the following command on Linux:
 
+```
+lscpu | grep -P '(?=.*avx )(?=.*sse4.2 )(?=.*cx16 )(?=.*popcnt )' > /dev/null \
+  && echo "Supported" \
+  || echo "Not supported"
+```
 
 ## Cost Estimation {#cost-estimation}
 


### PR DESCRIPTION
Here are some motivating points for the changes here:

* 8-core (16-thread) implies that SMT is required to run `neard` which
  is not exactly the case. There are a couple modern intel chips which
  have SMT disabled, and a fair number of people running validators may
  want to disable SMT due to CPU vulnerability concerns. OpenBSD in
  particular disables SMT by default.
* i7/Xeon does not particularly mean anything much in terms of
  performance characteristics. A current generation Alder Lake i5 can
  easily outperform an i7 from the previous generation. Xeon is useful
  as an identifier for server-class hardware and features (such as ECC
  memory), but given that i7 is okay…
* We require a CPU with the x86_64-v2 feature level + AVX. “AVX support”
  does not really convey this adequately, so I went ahead and listed the
  specific CPU features we are looking for.