### PR TITLE
Removed `keyStore setup` link under `Connect` section

### DIFF
--- a/docs/api/naj-quick-reference.md
+++ b/docs/api/naj-quick-reference.md
@@ -177,8 +177,6 @@ const near = await connect(config);
 </TabItem>
 </Tabs>
 
-[`keyStore setup`](/docs/api/naj-quick-reference#key-store)
-
 ## Wallet {#wallet}
 
 ### Connection {#connection}


### PR DESCRIPTION
Removed `keyStore setup` link under `Connect` section because the link was redirecting to same page instead of any other page . 
I don't find any reason for redirecting user to same page , so I thought of removing it . It can be useful if the link redirects the user to some another page which may have a javascript file with whole config code written so that user can directly copy & paste it in it's code.