### PR TITLE
passed `.near-credentials` path in `UnencryptedFileSystemKeyStore()`

### DIFF
--- a/docs/develop/front-end/introduction.md
+++ b/docs/develop/front-end/introduction.md
@@ -240,11 +240,16 @@ npm install near-api-js
 To do anything useful on the NEAR platform you first have to establish a connection.
 
 ```js
-// configure network settings and key storage
+// configure key storage
+const homedir = require("os").homedir();
+const CREDENTIALS_DIR = ".near-credentials";
+const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
+
+// configure network settings
 const config = {
   nodeUrl: "https://rpc.testnet.near.org",
   deps: {
-    keyStore: new nearApi.keyStores.UnencryptedFileSystemKeyStore(),
+    keyStore: new nearApi.keyStores.UnencryptedFileSystemKeyStore(credentialsPath),
   },
 };
 


### PR DESCRIPTION
passed `.near-credentials` path in `UnencryptedFileSystemKeyStore()` which would otherwise give error:
`The "path" argument must be of type string. Received undefined`

It will be good idea to tell user to pass `.near-credentials` file path otherwise he/she will be confused about it and has to search a level more about it in docs .
I get the idea about it from this [page](https://docs.near.org/docs/api/naj-quick-reference#key-store)