### PR TITLE
`path` is undefined without requiring `path` module

### DIFF
--- a/docs/api/naj-quick-reference.md
+++ b/docs/api/naj-quick-reference.md
@@ -61,7 +61,7 @@ const keyStore = new keyStores.BrowserLocalStorageKeyStore();
 const { keyStores } = nearAPI;
 const homedir = require("os").homedir();
 const CREDENTIALS_DIR = ".near-credentials";
-const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
+const credentialsPath = require("path").join(homedir, CREDENTIALS_DIR);
 const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
 ```
 


### PR DESCRIPTION
`path` is undefined without requiring (importing) `path` module in node.js