### PR TITLE
Update AssemblyScript Array example

### DIFF
--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -519,21 +519,12 @@ Arrays are similar to Arrays in other languages. One key difference is in how th
 _(from the AssemblyScript documentation):_
 
 ```ts
-// The Array constructor implicitly sets `.length = 10`, leading to an array of
-// ten times `null` not matching the value type `string`. So, this will error:
-var arr = new Array<string>(10);
-// arr.length == 10 -> ERROR
-
-// To account for this, the .create method has been introduced that initializes
-// the backing capacity normally but leaves `.length = 0`. So, this will work:
-var arr = Array.create<string>(10);
-// arr.length == 0 -> OK
-
-// When pushing to the latter array or subsequently inserting elements into it,
-// .length will automatically grow just like one would expect, with the backing
-// buffer already properly sized (no resize will occur). So, this is fine:
-for (let i = 0; i < 10; ++i) arr[i] = "notnull";
-// arr.length == 10 -> OK
+var arr = new Array<string>(10)
+// arr[0]; // would error 😢
+for (let i = 0; i < arr.length; ++i) {
+  arr[i] = ""
+}
+arr[0]; // now it works 😊
 ```
 
 There is currently no syntactic sugar for array iterators like `map`.

--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -521,9 +521,9 @@ _(from the AssemblyScript documentation):_
 ```ts
 // The Array constructor implicitly sets `.length = 10`, leading to an array of
 // ten times `null` not matching the value type `string`. So, this will error:
-var arr = new Array<string>(10)
+var arr = new Array<string>(10);
 // arr[0]; // would error 😢
-arr.fill("")
+arr.fill("");
 arr[0]; // now it works 😊
 ```
 

--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -519,11 +519,11 @@ Arrays are similar to Arrays in other languages. One key difference is in how th
 _(from the AssemblyScript documentation):_
 
 ```ts
+// The Array constructor implicitly sets `.length = 10`, leading to an array of
+// ten times `null` not matching the value type `string`. So, this will error:
 var arr = new Array<string>(10)
 // arr[0]; // would error 😢
-for (let i = 0; i < arr.length; ++i) {
-  arr[i] = ""
-}
+arr.fill("")
 arr[0]; // now it works 😊
 ```
 

--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -527,8 +527,6 @@ for (let i = 0; i < arr.length; ++i) {
 arr[0]; // now it works 😊
 ```
 
-There is currently no syntactic sugar for array iterators like `map`.
-
 ### Iteration {#iteration}
 
 Iteration follows the standard AssemblyScript format:


### PR DESCRIPTION
The `Array.create` function is deprecated, and the AssemblyScript documentation has been updated since.

I stumbled upon a StackOverflow question where someone referred to the current example, and was wondering why `Array.create` didn't work. I gave my answer here https://stackoverflow.com/a/70580668/1471485

I also noticed from the AssemblyScript docs that [map is supported now](https://www.assemblyscript.org/stdlib/array.html#instance-members). I therefore removed the sentence saying that it's not supported. 