### PR TITLE
deploy-on-mainnet: create validator key before using it

### DIFF
--- a/docs/develop/node/validator/deploy-on-mainnet.md
+++ b/docs/develop/node/validator/deploy-on-mainnet.md
@@ -4,78 +4,142 @@ title: Deploy Node on Mainnet
 sidebar_label: Deploy Node on Mainnet
 ---
 
+Deploying a node on `mainnet` is similar to deploying one on `testnet`
+and requires the following steps:
 
-Deploying a node on `mainnet` is similar to deploying on `testnet`:
-1. Create your `mainnet` wallet
-2. Deploy your `mainnet` staking pool
-3. Build and run your `mainnet` validator node
+1. Create `mainnet` wallet.
+2. Build `mainnet` validator node daemon.
+3. Initialise the node.
+4. Deploy `mainnet` staking pool.
+5. Run the validator node.
 
-### 1. Create your `mainnet` Wallet {#1-create-your-mainnet-wallet}
-- Go to [wallet.near.org](https://wallet.near.org/) and create an account.
 
-### 2. Deploy your `mainnet` Staking Pool {#2-deploy-your-mainnet-staking-pool}
-You can instantly deploy the staking pool with [near-cli](https://github.com/near/near-cli), using the command `near call`:
+### 1. Create `mainnet` wallet {#create-wallet}
 
-```
-near call poolv1.near create_staking_pool '{"staking_pool_id":"<POOL_ID>", "owner_id":"<OWNER_ID>", "stake_public_key":"<VALIDATOR_KEY>", "reward_fee_fraction": {"numerator": <X>, "denominator": <Y>}}' --account_id <OWNER_ID> --amount 30 --gas 300000000000000
-```
+If you don’t have a NEAR account, first go to [NEAR
+Wallet](https://wallet.near.org/) and create one.
 
-The command will invoke the `staking-pool-factory` from [NEAR Core Contracts](https://github.com/near/core-contracts), passing the following parameters:
 
-- `poolv1.near` is the staking pool factory
-- `POOL_ID` is the name of your validator (and the staking pool associated with it)
-- `OWNER_ID` is the wallet that controls the pool, see the [owner-only methods](https://github.com/near/core-contracts/tree/master/staking-pool#owner-only-methods) for more information
-- `VALIDATOR_KEY` is the validator node public key, from the file `~/.near/validator_key.json`
-- `{"numerator": <X>, "denominator": <Y>}` set the validator fees. `x=10` and `y=100` equals to 10%
-- `--amount 30` attaches 30 $NEAR to the transaction to pay the contract storage
-- `--gas 300000000000000` specifies the amount of gas for the transaction (optional)
+### 2. Build `mainnet` validator node daemon {#build-node}
 
-<blockquote class="info">
-<strong>Heads Up:</strong><br /><br />
-If your POOL_ID is "buildlinks", the staking pool factory will deploy a contract called "buildlinks.poolv1.near", and your node will appear in the Explorer as "buildlinks.poolv1.near"
-</blockquote>
-
-### 3. Build and run your mainnet validator node {#3-build-and-run-your-mainnet-validator-node}
-
-- Clone the [`nearcore`](https://github.com/near/nearcore) repository:
+To build the validator first clone the [`nearcore`
+repository](https://github.com/near/nearcore):
 
 ```bash
 git clone https://github.com/near/nearcore.git
-```  
-
-- Create an environment variable that finds the [most recent stable release](https://github.com/near/nearcore/releases):
-
-```bash
-export NEAR_RELEASE_VERSION=$(curl -s https://github.com/near/nearcore/releases/latest | tr '/" ' '\n' | grep "[0-9]\.[0-9]*\.[0-9]" | head -n 1)
 ```
 
-- Go to the root directory and checkout the branch:
+Once that’s done, figure out [the most recent stable
+release](https://github.com/near/nearcore/releases).  Stable releases
+are ones without `-rc.<number>` suffix (‘rc’ stands for ‘release
+candidate’).  This can be done automatically as follows:
+
+```bash
+NEAR_RELEASE_VERSION=$(curl -s https://github.com/near/nearcore/releases/latest |
+                       tr '/" ' '\n' | grep "[0-9]\.[0-9]*\.[0-9]" | head -n 1)
+```
+
+Now, go to the cloned repository’s root directory and checkout the
+code corresponding to the latest stable release:
 
 ```bash
 cd nearcore
-git checkout $NEAR_RELEASE_VERSION
+git checkout "refs/heads/${NEAR_RELEASE_VERSION:?}"
 ```
 
-- Build the binary using Makefile target (note that building with
-  a `cargo build --release` is not sufficient to create fully
-  optimized executable):
+Finally, build the executable using `make`.  Note that building with
+`cargo build --release` command *is not* sufficient to create fully
+optimised executable:
 
 ```bash
 make neard
 ```
 
-- configure the `chain-id` and `account-id`:
+
+### 3. Initialise the node {#init-node}
+
+Once the daemon executable is built it’s time to initialise the node.
 
 ```bash
-target/release/neard init --chain-id="mainnet" --account-id=<YOUR_STAKING_POOL_ID>
+./target/release/neard init --chain-id=mainnet \
+                            --account-id="<POOL_ID>.poolv1.near"
 ```
-  - After the build process is done, check that the configuration file located at `/HOME_DIR/.near/config.json` is the same as [this mainnet config.json](https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/mainnet/config.json).
 
-  - Now, start your node with the following command:
+`<POOL_ID>` is the name you want to use for your staking pool.  Note
+that at this point the `<POOL_ID>.poolv1.near` account doesn’t yet
+exist.  We’re going to create it in the next step.
+
+This command will create a `~/.near/validator_key.json` file which
+will contain validator’s private key.  It’s a good idea to back this
+file up in a secure location.  For now, read the validator’s public
+key from this file:
+
+```bash
+grep public_key ~/.near/validator_key.json
 ```
-target/release/neard run
+
+
+### 4. Deploy `mainnet` Staking Pool {#deploy-staking-pool}
+
+You can deploy the staking pool with [near-cli](https://github.com/near/near-cli),
+using the `near call` command:
+
+```bash
+near call poolv1.near create_staking_pool '{
+    "staking_pool_id": "<POOL_ID>",
+    "owner_id": "<OWNER_ID>",
+    "stake_public_key": "<VALIDATOR_KEY>",
+    "reward_fee_fraction": {"numerator": <X>, "denominator": <Y>}
+}' --account_id <OWNER_ID> --amount 30 --gas 300000000000000
 ```
- - Or you can start your node without the JSON RPC endpoint by running the above command with an additional flag `--disable-rpc`. With the `--disable-rpc` flag present, node won’t start the HTTP server offering the JSON RPC endpoint. This reduces resource use and attack vector by closing a listening port.
+
+It will invoke the `staking-pool-factory` method from [NEAR Core
+Contracts](https://github.com/near/core-contracts), passing the
+following parameters:
+
+- `poolv1.near` is the staking pool factory,
+- `<POOL_ID>` is the name of your validator (and the staking pool
+  associated with it),
+- `<OWNER_ID>` is the wallet that controls the pool (see [owner-only
+  methods](https://github.com/near/core-contracts/tree/master/staking-pool#owner-only-methods)
+  for more information),
+- `<VALIDATOR_KEY>` is the validator node public key read in the
+  previous step from the `~/.near/validator_key.json` file,
+- `{"numerator": <X>, "denominator": <Y>}` sets the validator fees
+  (for example`X=10` and `Y=100` means 10%),
+- `--amount 30` attaches 30 $NEAR to the transaction to pay the
+  contract storage,
+- `--gas 300000000000000` specifies the amount of gas for the
+  transaction (optional).
+
+Note that if your `<POOL_ID>` is ‘buildlinks’, the staking pool
+factory will deploy a contract called ‘buildlinks.poolv1.near’, and
+your node will appear in the Explorer as ‘buildlinks.poolv1.near’.
+This corresponds to the account identifier used in the previous step.
+
+
+### 5. Run the validator node {#run-the-node}
+
+Once the daemon is built, node is initialised and staking pool
+created, the validator can be started.  To make sure the node has been
+set up correctly, check that the configuration file located at
+`~/.near/config.json` is the same as [this mainnet
+config.json](https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/mainnet/config.json):
+
+```bash
+sha1sum <~/.near/config.json
+curl -s https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/mainnet/config.json | sha1sum
+```
+
+If everything is in order, start your node with the following command:
+
+```
+./target/release/neard run
+```
+
+You can start your node without the JSON RPC endpoint by running the
+above command with an additional `--disable-rpc` flag.  This reduces
+resource use and attack vector by closing a listening port.
 
 
 >Got a question?

--- a/docs/develop/node/validator/deploy-on-mainnet.md
+++ b/docs/develop/node/validator/deploy-on-mainnet.md
@@ -9,7 +9,7 @@ and requires the following steps:
 
 1. Create `mainnet` wallet.
 2. Build `mainnet` validator node daemon.
-3. Initialise the node.
+3. Initialize the node.
 4. Deploy `mainnet` staking pool.
 5. Run the validator node.
 
@@ -49,16 +49,16 @@ git checkout "refs/heads/${NEAR_RELEASE_VERSION:?}"
 
 Finally, build the executable using `make`.  Note that building with
 `cargo build --release` command *is not* sufficient to create fully
-optimised executable:
+optimized executable:
 
 ```bash
 make neard
 ```
 
 
-### 3. Initialise the node {#init-node}
+### 3. Initialize the node {#init-node}
 
-Once the daemon executable is built it’s time to initialise the node.
+Once the daemon executable is built it’s time to initialize the node.
 
 ```bash
 ./target/release/neard init --chain-id=mainnet \
@@ -120,7 +120,7 @@ This corresponds to the account identifier used in the previous step.
 
 ### 5. Run the validator node {#run-the-node}
 
-Once the daemon is built, node is initialised and staking pool
+Once the daemon is built, node is initialized and staking pool
 created, the validator can be started.  To make sure the node has been
 set up correctly, check that the configuration file located at
 `~/.near/config.json` is the same as [this mainnet


### PR DESCRIPTION
Right now, the ‘Deploy Node on Mainnet’ instructions are a bit
confusing.  Most notably, in the second step they reference
`validator_key.json` file which is created in the third step.  It’s
also not obvious what account identifier should the validator node
use.

Rewrite the guide so that we first initialise the node (which
generates `validator_key.json` file) and only then use the validator
public key.  Also make it clear that the account identifier needs to
contain the `.poolv1.near` suffix.

Fixes: https://github.com/near/docs/issues/892
Issue: https://github.com/near/nearcore/issues/6010