### PR TITLE
U128 takes string as input not integer

### DIFF
--- a/docs/tutorials/contracts/nfts/3-enumeration.md
+++ b/docs/tutorials/contracts/nfts/3-enumeration.md
@@ -81,7 +81,7 @@ Once the updated contract has been redeployed, you can test and see if these new
 Let's query for a list of non-fungible tokens on the contract. Use the following command to query for the information of up to 50 NFTs starting from the 10th item:
 
 ```bash
-near view $NFT_CONTRACT_ID nft_tokens '{"from_index": 10, "limit": 50}'
+near view $NFT_CONTRACT_ID nft_tokens '{"from_index": "10", "limit": 50}'
 ```
 
 This command should return an output similar to the following:


### PR DESCRIPTION
Error  associated with previous version:
```json
{
  "error": "wasm execution failed with error: FunctionCallError(HostError(GuestPanic { panic_msg: \"panicked at 'Failed to deserialize input from JSON.: Error(\\\"invalid type: string \\\\\\\"50\\\\\\\", expected u64\\\", line: 1, column: 31)', src\\\\enumeration.rs:3:1\" }))",
  "logs": [],
  "block_height": 80155765,
  "block_hash": "2yGj2zigEdWmAQjqpatst3Fu5K1RWGPCpYFJ8qMoBz4Q"
}
```
