### PR TITLE
Clarify @nearBindgen inheritance limits

### DIFF
--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -166,7 +166,11 @@ export class TextMessage {
 // see https://github.com/near/near-sdk-as/blob/master/assembly/__tests__/runtime/model.ts
 ```
 
-`@nearBindgen` is a decorator made for the serialization of custom classes before they are saved to storage onto the blockchain. Importantly, `@nearBindgen` does not support class inheritance
+`@nearBindgen` is a decorator made for the serialization of custom classes before they are saved to storage onto the blockchain.
+
+:::note
+Please note that `@nearBindgen` does not support class inheritance.
+:::
 
 #### Models are composable {#models-are-composable}
 

--- a/docs/develop/contracts/as/intro.md
+++ b/docs/develop/contracts/as/intro.md
@@ -166,7 +166,7 @@ export class TextMessage {
 // see https://github.com/near/near-sdk-as/blob/master/assembly/__tests__/runtime/model.ts
 ```
 
-`@nearBindgen` is a decorator made for the serialization of custom classes before they are saved to storage onto the blockchain
+`@nearBindgen` is a decorator made for the serialization of custom classes before they are saved to storage onto the blockchain. Importantly, `@nearBindgen` does not support class inheritance
 
 #### Models are composable {#models-are-composable}
 


### PR DESCRIPTION
As discussed in https://github.com/near/near-sdk-as/issues/695 `@nearBindgen` does not support inheritence. Updated the docs to make this clear.