### PR TITLE
Improve data snapshot instructions

### DIFF
--- a/docs/develop/node/archival/run-archival-node-without-nearup.md
+++ b/docs/develop/node/archival/run-archival-node-without-nearup.md
@@ -128,7 +128,7 @@ or
 
 ```bash
 $ rm ~/.near/config.json
-$ wget https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/testnet/config.json -P ~/.near/
+$ wget -P ~/.near https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/testnet/config.json
 ```
 
 ### Configuration Update {#configuration-update}
@@ -158,15 +158,16 @@ The node is ready to be started however you must first sync up with the network.
 | testnet | https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/archive/data.tar |
 
 
-1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar) to `~/.near`.
+1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar) to `~/.near/data`.
 
 or
 
 2. Run the following commands:
 
 ```bash
-$ wget https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar -P ~/.near/
-$ tar -xf ~/.near/data.tar
+$ wget -P ~/.near https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar
+$ mkdir -p ~/.near/data
+$ tar -xf ~/.near/data.tar -C ~/.near/data
 $ rm ~/.near/data.tar
 ```
 
@@ -288,15 +289,16 @@ The node is ready to be started however you must first sync up with the network.
 | mainnet | https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/archive/data.tar |
 
 
-1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar) to `~/.near`.
+1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar) to `~/.near/data`.
 
 or
 
 2. Run the following commands:
 
 ```bash
-$ wget https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar -P ~/.near/
-$ tar -xf ~/.near/data.tar
+$ wget -P ~/.near https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar
+$ mkdir -p ~/.near/data
+$ tar -xf ~/.near/data.tar -C ~/.near/data
 $ rm ~/.near/data.tar
 ```
 

--- a/docs/develop/node/intro/snapshots.md
+++ b/docs/develop/node/intro/snapshots.md
@@ -24,8 +24,9 @@ Here are the available snapshots based on node type and network. Please note tha
 If you've [initialized the working directory for your node](/docs/develop/node/validator/compile-and-run-a-node#3-initialize-working-directory-1) without passing in a preferred location, the default working directory for your node is `~/.near`. It is recommended that you wget and untar into a `data` folder under `~/.near/`. The new `~/.near/data` is where your node will store historical states and write its state. To use the default location, run the following commands:
 
 ```bash
-$ wget ~/.near/data.tar https://near-protocol-public.s3-accelerate.amazonaws.com/backups/{mainnet|testnet}/{rpc|archive}/data.tar
-$ tar -xf ~/.near/data.tar
+$ wget -P ~/.near https://near-protocol-public.s3-accelerate.amazonaws.com/backups/{mainnet|testnet}/{rpc|archive}/data.tar
+$ mkdir -p ~/.near/data
+$ tar -xf ~/.near/data.tar -C ~/.near/data
 $ rm ~/.near/data.tar
 ```
 

--- a/docs/develop/node/rpc/run-rpc-node-without-nearup.md
+++ b/docs/develop/node/rpc/run-rpc-node-without-nearup.md
@@ -140,15 +140,16 @@ The node is ready to be started however you must first sync up with the network.
 | testnet | https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar |
 
 
-1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar) to `~/.near`.
+1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar) to `~/.near/data`.
 
 or
 
 2. Run the following commands:
 
 ```bash
-$ wget https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar -P ~/.near/
-$ tar -xf ~/.near/data.tar
+$ wget -P ~/.near https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar
+$ mkdir -p ~/.near/data
+$ tar -xf ~/.near/data.tar -C ~/.near/data
 $ rm ~/.near/data.tar
 ```
 
@@ -252,15 +253,16 @@ The node is ready to be started however you must first sync up with the network.
 | mainnet | https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar |
 
 
-1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar) to `~/.near`.
+1. Download and unpack the [tar file](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar) to `~/.near/data`.
 
 or
 
 2. Run the following commands:
 
 ```bash
-$ wget https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar -P ~/.near/
-$ tar -xf ~/.near/data.tar
+$ wget -P ~/.near https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar
+$ mkdir -p ~/.near/data
+$ tar -xf ~/.near/data.tar -C ~/.near/data
 $ rm ~/.near/data.tar
 ```
 


### PR DESCRIPTION
Firstly, `wget <file> <url>` is an invalid invocation so fix that to
using `-P` option.  (Another alternative would be to use `-O` option
but since existing documents already use `-P` use that consistently in
Node Data Snapshots section as well).  With that, move `-P` at the
front of the command so that it’s more obvious that the switch is
there and is necessary.

Secondly, for better or worse (*cough* worse *cough*) the `data.tar`
files do not include the `data` directory so make sure that
instructions indicate that the file needs to be extracted inside of
the `~/.near/data` directory.