### PR TITLE
Adding calbackUrl and meta to Call Contract

### DIFF
--- a/docs/api/naj-quick-reference.md
+++ b/docs/api/naj-quick-reference.md
@@ -456,6 +456,23 @@ await contract.method_name(
 ```
 
 </TabItem>
+<TabItem value="method" label="Change Method w/ callbackUrl and meta">
+
+```js
+await contract.method_name(
+  {
+    callbackUrl: 'https://example.com/callback', // callbackUrl after the transaction approved (optional)
+    meta: 'some info', // meta information NEAR Wallet will send back to the application. `meta` will be attached to the `callbackUrl` as a url search param
+    args: {
+        arg_name: "value" // argument name and value - pass empty object if no args required
+    },
+    gas: 300000000000000, // attached GAS (optional)
+    amount: 1000000000000000000000000 // attached deposit in yoctoNEAR (optional)
+  }
+);
+```
+
+</TabItem>
 <TabItem value="view" label="View Method">
 
 ```js


### PR DESCRIPTION
Updating the Call Contract method with a callbackUrl using the example from https://github.com/near/near-api-js/blob/master/src/contract.ts