### PR TITLE
Fixed typo in reset test

### DIFF
--- a/docs/develop/contracts/rust/intro.md
+++ b/docs/develop/contracts/rust/intro.md
@@ -397,7 +397,7 @@ mod tests {
         contract.increment();
         contract.reset();
         println!("Value after reset: {}", contract.get_num());
-        // confirm that we received -1 when calling get_num
+        // confirm that we received 0 when calling get_num
         assert_eq!(0, contract.get_num());
     }
 }


### PR DESCRIPTION
Someone forgot to change out the `-1` to a `0` when they copied and pasted to make the next text.