### PR TITLE
Update epoch.md

### DIFF
--- a/docs/concepts/epoch.md
+++ b/docs/concepts/epoch.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 > An **epoch** is a unit of time when validators of the network remain constant.
 
-- Both `testnet` and `mainnet` have an epoch duration of ~12 hours or 43,200 seconds to be exact.
+- Both `testnet` and `mainnet` have an epoch duration of 43,200 blocks. Ideally, new blocks are created every second, meaning that epochs last for ~12 hours. In reality, blocks take slightly longer to be created.
 - You can view this setting by querying the **[`protocol_config`](/docs/api/rpc#protocol-config)** RPC endpoint and searching for `epoch_length`.
 
 **Note:** Nodes garbage collect blocks after 5 epochs (~2.5 days) unless they are [archival nodes](/docs/roles/integrator/exchange-integration#running-an-archival-node).


### PR DESCRIPTION
The documentation currently says that each epoch takes 43,200 seconds. This is not the case. Each epoch takes 43,200 blocks, where each block ideally takes a second to be created. In reality, it takes about 1.3 seconds for each block to be created. This discrepancy is confusing for developers building on NEAR.