### PR TITLE
Update network.md

### DIFF
--- a/docs/api/rpc/network.md
+++ b/docs/api/rpc/network.md
@@ -436,7 +436,7 @@ Here is the exhaustive list of the error variants that can be returned by `netwo
 - method: `validators`
 - params: `["block hash"]`, `[block number]`, or `[null]` for the latest block
 
-**Note:** For `["block hash"]` & `[block number]` you will need to query recent blocks as they become garbage collected after five [epochs](/docs/concepts/epoch).
+**Note:** For `["block hash"]` & `[block number]` you will need to query from the last block in an epoch.
 
 `[block number]`
 
@@ -1290,6 +1290,7 @@ Here is the exhaustive list of the error variants that can be returned by `valid
         <ul>
           <li>Check that the requested block is legit</li>
           <li>If the block had been produced more than 5 epochs ago, try to send your request to an archival node</li>
+          <li>Check that the requested block is the last block of some epoch</li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
When making validator requests, one must make a query from the last block in an epoch. This fact was not explicitly stated in the documentation.