### PR TITLE
Test local search

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -25,7 +25,19 @@ module.exports = {
       myFont: ["Inter", "sans-serif"],
     },
   },
-  themes: ["@saucelabs/theme-github-codeblock"],
+  themes: ["@saucelabs/theme-github-codeblock",
+    [
+      require.resolve("@easyops-cn/docusaurus-search-local"),
+      {
+        hashed: true,
+        indexPages: false,
+        indexBlog: false,
+        docsRouteBasePath: ['/'],
+        docsDir: ["../docs"],
+        language: ["en"],
+      },
+    ],
+  ],
   onBrokenLinks: "log",
   onBrokenMarkdownLinks: "log",
   presets: [
@@ -137,6 +149,7 @@ module.exports = {
         src: "img/near_logo.svg",
       },
     },
+/*
     algolia: {
       // The application ID provided by Algolia
       appId: "0LUM67N2P2",
@@ -152,6 +165,7 @@ module.exports = {
       //... other Algolia params
       placeholder: "Search the Docs...",
     },
+*/
   },
   i18n: {
     defaultLocale: "en",

--- a/website/package.json
+++ b/website/package.json
@@ -26,9 +26,10 @@
   },
   "dependencies": {
     "@crowdin/cli": "^3.7.9",
-    "@docusaurus/core": "^2.0.0-beta.17",
-    "@docusaurus/plugin-sitemap": "^2.0.0-beta.17",
-    "@docusaurus/preset-classic": "^2.0.0-beta.17",
+    "@docusaurus/core": "^2.0.0-rc.1",
+    "@docusaurus/plugin-sitemap": "^2.0.0-rc.1",
+    "@docusaurus/preset-classic": "^2.0.0-rc.1",
+    "@easyops-cn/docusaurus-search-local": "^0.30.2",
     "@saucelabs/theme-github-codeblock": "^0.1.1",
     "clsx": "^1.1.1",
     "gleap": "^6.9.4",

--- a/website/src/theme/Footer/index.js
+++ b/website/src/theme/Footer/index.js
@@ -12,7 +12,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import styles from './styles.module.css';
 import ThemedImage from '@theme/ThemedImage';
-import IconExternalLink from '@theme/IconExternalLink';
+//import IconExternalLink from '@theme/IconExternalLink';
 
 function FooterLink({to, href, label, prependBaseUrlToHref, ...props}) {
   const toUrl = useBaseUrl(to);


### PR DESCRIPTION
Documentation search by Algolia has been pointing to broken links for over a week, since we launched new-docs.

Moving to local search as a workaround.