### PR TITLE
Create Account Guide Invalid Link

### DIFF
--- a/docs/3.tutorials/fts/simple-fts.md
+++ b/docs/3.tutorials/fts/simple-fts.md
@@ -16,7 +16,7 @@ To complete this tutorial successfully, you'll need:
 ### Wallet
 
 To store your fungible tokens you'll need a [NEAR Wallet](https://wallet.testnet.near.org/).
-If you don't have one yet, you can create one easily by following [these instructions](https://wiki.near.org/getting-started/creating-a-near-wallet).
+If you don't have one yet, you can create one easily by following [these instructions](https://testnet.mynearwallet.com/create).
 
 Once you have your Wallet account, you can click on the [Balances Tab](https://wallet.testnet.near.org/?tab=balances) where all your Fungible Tokens will be listed:
 

--- a/docs/3.tutorials/fts/simple-fts.md
+++ b/docs/3.tutorials/fts/simple-fts.md
@@ -16,7 +16,7 @@ To complete this tutorial successfully, you'll need:
 ### Wallet
 
 To store your fungible tokens you'll need a [NEAR Wallet](https://wallet.testnet.near.org/).
-If you don't have one yet, you can create one easily by following [these instructions](https://testnet.mynearwallet.com/create).
+If you don't have one yet, you can create one easily by following [these instructions](https://wallet.testnet.near.org/create).
 
 Once you have your Wallet account, you can click on the [Balances Tab](https://wallet.testnet.near.org/?tab=balances) where all your Fungible Tokens will be listed:
 

--- a/docs/3.tutorials/nfts/0-intro.md
+++ b/docs/3.tutorials/nfts/0-intro.md
@@ -14,7 +14,7 @@ sidebar_label: Introduction
 To complete these tutorials successfully, you'll need:
 
 - [Rust](/develop/prerequisites)
-- [A NEAR Wallet](https://wiki.near.org/getting-started/creating-a-near-wallet)
+- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 :::info New to Rust?

--- a/docs/3.tutorials/nfts/0-intro.md
+++ b/docs/3.tutorials/nfts/0-intro.md
@@ -14,7 +14,7 @@ sidebar_label: Introduction
 To complete these tutorials successfully, you'll need:
 
 - [Rust](/develop/prerequisites)
-- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
+- [A NEAR Wallet](https://wallet.testnet.near.org/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 :::info New to Rust?

--- a/docs/3.tutorials/nfts/0-predeployed.md
+++ b/docs/3.tutorials/nfts/0-predeployed.md
@@ -10,7 +10,7 @@ sidebar_label: Pre-deployed Contract
 
 To complete this tutorial successfully, you'll need:
 
-- [A NEAR Wallet](https://wiki.near.org/getting-started/creating-a-near-wallet)
+- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 ## Using the NFT contract

--- a/docs/3.tutorials/nfts/0-predeployed.md
+++ b/docs/3.tutorials/nfts/0-predeployed.md
@@ -10,7 +10,7 @@ sidebar_label: Pre-deployed Contract
 
 To complete this tutorial successfully, you'll need:
 
-- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
+- [A NEAR Wallet](https://wallet.testnet.near.org/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 ## Using the NFT contract

--- a/docs/3.tutorials/nfts/js/0-intro.md
+++ b/docs/3.tutorials/nfts/js/0-intro.md
@@ -18,7 +18,7 @@ The JavaScript smart contracts used throughout this series have not been battle 
 To complete these tutorials successfully, you'll need:
 
 - [Node.js](/develop/prerequisites#nodejs)
-- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
+- [A NEAR Wallet](https://wallet.testnet.near.org/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 ---

--- a/docs/3.tutorials/nfts/js/0-intro.md
+++ b/docs/3.tutorials/nfts/js/0-intro.md
@@ -18,7 +18,7 @@ The JavaScript smart contracts used throughout this series have not been battle 
 To complete these tutorials successfully, you'll need:
 
 - [Node.js](/develop/prerequisites#nodejs)
-- [A NEAR Wallet](https://wiki.near.org/getting-started/creating-a-near-wallet)
+- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 ---

--- a/docs/3.tutorials/nfts/js/0-predeployed.md
+++ b/docs/3.tutorials/nfts/js/0-predeployed.md
@@ -14,7 +14,7 @@ The JavaScript smart contracts used throughout this series have not been battle 
 
 To complete this tutorial successfully, you'll need:
 
-- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
+- [A NEAR Wallet](https://wallet.testnet.near.org/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 ## Using the NFT contract

--- a/docs/3.tutorials/nfts/js/0-predeployed.md
+++ b/docs/3.tutorials/nfts/js/0-predeployed.md
@@ -14,7 +14,7 @@ The JavaScript smart contracts used throughout this series have not been battle 
 
 To complete this tutorial successfully, you'll need:
 
-- [A NEAR Wallet](https://wiki.near.org/getting-started/creating-a-near-wallet)
+- [A NEAR Wallet](https://testnet.mynearwallet.com/create)
 - [NEAR-CLI](/tools/near-cli#setup)
 
 ## Using the NFT contract

--- a/docs/3.tutorials/nfts/minting-nfts.md
+++ b/docs/3.tutorials/nfts/minting-nfts.md
@@ -23,7 +23,7 @@ To complete this tutorial successfully, you'll need:
 ## Wallet {#wallet}
 
 To store your non-fungible tokens you'll need a [NEAR Wallet](https://wallet.testnet.near.org/).
-If you don't have one yet, you can create one easily by following [these instructions](https://wiki.near.org/getting-started/creating-a-near-wallet).
+If you don't have one yet, you can create one easily by following [these instructions](https://testnet.mynearwallet.com/create).
 
 > **Tip:** for this tutorial we'll use a `testnet` wallet account. The `testnet` network is free and there's no need to deposit funds.
 

--- a/docs/3.tutorials/nfts/minting-nfts.md
+++ b/docs/3.tutorials/nfts/minting-nfts.md
@@ -23,7 +23,7 @@ To complete this tutorial successfully, you'll need:
 ## Wallet {#wallet}
 
 To store your non-fungible tokens you'll need a [NEAR Wallet](https://wallet.testnet.near.org/).
-If you don't have one yet, you can create one easily by following [these instructions](https://testnet.mynearwallet.com/create).
+If you don't have one yet, you can create one easily by following [these instructions](https://wallet.testnet.near.org/create).
 
 > **Tip:** for this tutorial we'll use a `testnet` wallet account. The `testnet` network is free and there's no need to deposit funds.
 

--- a/docs/6.integrator/balance.md
+++ b/docs/6.integrator/balance.md
@@ -7,7 +7,7 @@ sidebar_label: Balance Changes
 
 ## Prerequisites {#prerequisites}
 
-- [NEAR Account](https://wiki.near.org/getting-started/creating-a-near-wallet)
+- [NEAR Account](docs/6.integrator/balance.md)
 - [NEAR-CLI](/tools/near-cli)
 - Credentials for sender account stored locally by running [`near login`](/tools/near-cli#near-login)
 

--- a/docs/6.integrator/balance.md
+++ b/docs/6.integrator/balance.md
@@ -7,7 +7,7 @@ sidebar_label: Balance Changes
 
 ## Prerequisites {#prerequisites}
 
-- [NEAR Account](https://testnet.mynearwallet.com/create)
+- [NEAR Account](https://wallet.testnet.near.org/create)
 - [NEAR-CLI](/tools/near-cli)
 - Credentials for sender account stored locally by running [`near login`](/tools/near-cli#near-login)
 

--- a/docs/6.integrator/balance.md
+++ b/docs/6.integrator/balance.md
@@ -7,7 +7,7 @@ sidebar_label: Balance Changes
 
 ## Prerequisites {#prerequisites}
 
-- [NEAR Account](docs/6.integrator/balance.md)
+- [NEAR Account](https://testnet.mynearwallet.com/create)
 - [NEAR-CLI](/tools/near-cli)
 - Credentials for sender account stored locally by running [`near login`](/tools/near-cli#near-login)
 


### PR DESCRIPTION
Updated link to create account in docs as before it was pointing to mainnet article. Now it points to testnet. Thanks @flmel for pointing this out.