### PR TITLE
Add note about deprecation of empty proofs in view_state response

### DIFF
--- a/docs/5.api/rpc/contracts.md
+++ b/docs/5.api/rpc/contracts.md
@@ -852,11 +852,11 @@ http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare method=query \
 ```
 </p>
 
-**Note**: Currently, the response always includes `proof` field directly in the
-`result` object and also `proof` fields within objects in the `values` list.  In
-the future the former will be included only if non-empty and the latter will be
-removed altogether.  When parsing the result, you should accept object with or
-without those fields set.
+**Note**: Currently, the response includes a `proof` field directly in the
+`result`, and a `proof` fields on each element of the `values` list.  In
+the future, the `result.proof` will be included only if the result is **not empty**,
+and the `proof` field will be removed from all `values`. When parsing the result, you
+should accept objects with or without these fields set.
 </details>
 
 > **Heads up**

--- a/docs/5.api/rpc/contracts.md
+++ b/docs/5.api/rpc/contracts.md
@@ -850,8 +850,13 @@ http post https://rpc.testnet.near.org jsonrpc=2.0 id=dontcare method=query \
   "id": "dontcare"
 }
 ```
-
 </p>
+
+**Note**: Currently, the response always includes `proof` field directly in the
+`result` object and also `proof` fields within objects in the `values` list.  In
+the future the former will be included only if non-empty and the latter will be
+removed altogether.  When parsing the result, you should accept object with or
+without those fields set.
 </details>
 
 > **Heads up**


### PR DESCRIPTION
See https://github.com/near/nearcore/pull/7603

Issue: https://github.com/near/nearcore/pull/2076