### PR TITLE
Add chainstack as a provider

### DIFF
--- a/docs/5.api/rpc/providers.md
+++ b/docs/5.api/rpc/providers.md
@@ -17,3 +17,4 @@ pick a few different ones for redundancy and balancing.
 | [https://rpc.ankr.com/near](./)               | ankr.com   | https://www.ankr.com/docs/build-blockchain/chains/v2/near/          |
 | [https://public-rpc.blockpi.io/http/near](./) | BlockPi    | https://chains.blockpi.io/#/near                                    |
 | -                                       | figment.io | https://docs.figment.io/guides/staking-api/Near/delegate/ |
+| -                                       | Chainstack | https://chainstack.com/build-better-with-near/            |


### PR DESCRIPTION
Chainstack makes sure you get access to robust and scalable infrastructure, ready for your NEAR journey, in a matter of minutes.