### PR TITLE
Delete Sender from ContractMethods

### DIFF
--- a/docs/4.tools/near-api-js/quick-reference.md
+++ b/docs/4.tools/near-api-js/quick-reference.md
@@ -517,7 +517,6 @@ For example if you deployed a contract with `my_method` function on it, then thi
 ```js
 const contract = new Contract(account, {
   changeMethods: ["my_method"],
-  sender: account
 });
 // `contract` object has `my_method` on it: 
 contract.my_method()
@@ -538,7 +537,6 @@ const contract = new Contract(
     // name of contract you're connecting to
     viewMethods: ["getMessages"], // view methods do not change state but usually return a value
     changeMethods: ["addMessage"], // change methods modify state
-    sender: account, // account object to initialize and sign transactions.
   }
 );
 ```
@@ -558,7 +556,6 @@ const contract = new Contract(
     // name of contract you're connecting to
     viewMethods: ["getMessages"], // view methods do not change state but usually return a value
     changeMethods: ["addMessage"], // change methods modify state
-    sender: wallet.account(), // account object to initialize and sign transactions.
   }
 );
 ```


### PR DESCRIPTION
The sender field in the ContractMethods object is no longer supported.
<img width="1418" alt="Screen Shot 2022-09-30 at 7 58 49 PM" src="https://user-images.githubusercontent.com/62624378/193376927-fb6bca52-8359-4deb-bc24-5a4ce532c1a5.png">
Typescript error before making edits.