### PR TITLE
Mention ECDSA Public Key Recovery

### DIFF
--- a/docs/2.develop/contracts/environment/environment.md
+++ b/docs/2.develop/contracts/environment/environment.md
@@ -147,4 +147,4 @@ If you already [estimated the Gas](/concepts/basics/transactions/gas#accurate-es
 
 ## Recover ECDSA Public Key from Signed Messages
 
-The environment gives you access to the `ecrecover` (function)[https://github.com/near/near-sdk-rs/blob/83df045aded3e1b14c372ebc36a53ca71cfb4f07/near-sdk/src/environment/env.rs#L370], which allows you to recover the public key of the signer from a signed message. Through a host function, you can invoke the `ecrecover` implementation which should be more optimized than other crates when targeting `wasm`. 
+The environment gives you access to the `ecrecover` function in [Rust](https://github.com/near/near-sdk-rs/blob/83df045aded3e1b14c372ebc36a53ca71cfb4f07/near-sdk/src/environment/env.rs#L370) or [JavaScript](https://github.com/near/near-sdk-js/blob/06c9ed68d8301814f872fccce5625a333b7ac68a/src/api.ts#L221), which allows you to recover the public key of the signer from a signed message. Through a host function, you can invoke the `ecrecover` implementation which should be more optimized than other crates when targeting `wasm`. 

--- a/docs/2.develop/contracts/environment/environment.md
+++ b/docs/2.develop/contracts/environment/environment.md
@@ -142,3 +142,9 @@ If you already [estimated the Gas](/concepts/basics/transactions/gas#accurate-es
   </TabItem>
 </Tabs>
 :::
+
+---
+
+## Recover ECDSA Public Key from Signed Messages
+
+The environment gives you access to the `ecrecover` (function)[https://github.com/near/near-sdk-rs/blob/83df045aded3e1b14c372ebc36a53ca71cfb4f07/near-sdk/src/environment/env.rs#L370], which allows you to recover the public key of the signer from a signed message. Through a host function, you can invoke the `ecrecover` implementation which should be more optimized than other crates when targeting `wasm`. 


### PR DESCRIPTION
This PR adds a short section on recovering public keys from signed messages with the Rust SDK. 

It follows questions from Discord and is in line with this reply: https://discord.com/channels/490367152054992913/855524499755499520/958736044935766107

