### PR TITLE
fix: misleading links

### DIFF
--- a/0.old/roles/integrator/faq.md
+++ b/0.old/roles/integrator/faq.md
@@ -34,7 +34,7 @@ Our plan is to have a transparent Bug Bounty program with clear guidelines for p
 
 ### What contracts should we be aware of right now? {#what-contracts-should-we-be-aware-of-right-now}
 
-We have developed a number of [initial contracts](https://github.com/near/initial-contracts) with **ones in bold** being most mature at time of writing
+We have developed a number of [initial contracts](https://github.com/near/core-contracts) with **ones in bold** being most mature at time of writing
 
 - **Staking Pool / Delegation contract**
 - **Lockup / Vesting contract**

--- a/docs/1.concepts/basics/networks.md
+++ b/docs/1.concepts/basics/networks.md
@@ -16,7 +16,7 @@ NEAR Protocol operates on several networks each operating with their own indepen
 
 `mainnet` is for production ready smart contracts and live token transfers. Contracts ready for `mainnet` should have gone through rigorous testing and independent security reviews if necessary. `mainnet` is the only network where state is guaranteed to persist over time _(subject to the typical security guarantees of the network's validation process)_.
 
-* [ Status: [https://status.nearprotocol.com/](./) ]
+* [ [Status](https://rpc.mainnet.near.org/status) ]
 * [ [Explorer](https://explorer.near.org) ]
 * [ [Wallet](https://wallet.near.org) ]
 * [ [Data Snapshots](https://near-nodes.io/intro/node-data-snapshots) ]
@@ -26,7 +26,7 @@ NEAR Protocol operates on several networks each operating with their own indepen
 
 `testnet` is a public network and the final testing network for `nearcore` changes before deployment to `mainnet`. `testnet` is intended for testing all aspects of the NEAR platform prior to `mainnet` deployment. From account creation, mock token transfers, development tooling, and smart contract development, the `testnet` environment closely resembles `mainnet` behavior. All `nearcore` changes are deployed as release candidates on first testnet, before the changes are released on `mainnet`. A number of `testnet` validators validate transactions and create new blocks. dApp developers deploy their applications on `testnet` before deploying on `mainnet`. It is important to note that `testnet` has its own transactions and states.
 
-* [ Status: [https://rpc.testnet.near.org/status](./) ]
+* [ [Status](https://rpc.testnet.near.org/status) ]
 * [ [Explorer](https://explorer.testnet.near.org) ]
 * [ [Wallet](https://wallet.testnet.near.org) ]
 * [ [Data Snapshots](https://near-nodes.io/intro/node-data-snapshots) ]
@@ -36,7 +36,7 @@ NEAR Protocol operates on several networks each operating with their own indepen
 
 `betanet` is a public network, where `nearcore` is run to test its stability and backward compatibility. Validators on `betanet` are participants in the Betanet Analysis Group, where they engage in active discussions, submit bug reports, and participate in issue resolution. On `betanet` protocol changes, there are automated hard forks, where the state is compressed into a new genesis. As such, new genesis exists frequently on `betanet`, and there are no historical data snapshots. `betanet` usually has daily releases with protocol features that are not yet stabilized. State is maintained as much as possible but there is no guarantees with its high volatility.
 
-* [ Status: [https://rpc.betanet.near.org/status](./) ]
+* [ [Status](https://rpc.betanet.near.org/status) ]
 * [ [Wallet](https://wallet.betanet.near.org) ]
 
 

--- a/docs/5.api/rpc/providers.md
+++ b/docs/5.api/rpc/providers.md
@@ -10,12 +10,12 @@ balancing.
 
 | Endpoint Root                           | Provider   | Documentation                                                       |
 | --------------------------------------- | ---------- | ------------------------------------------------------------------- |
-| [https://rpc.mainnet.near.org](./)            | NEAR       | [You are there!](setup.md)                                          |
-| [https://near-mainnet.api.pagoda.co/rpc/v1](./)      | Pagoda     | https://www.pagoda.co/console                                       |
-| [https://near-mainnet.infura.io/v3/](./)      | Infura     | https://docs.infura.io/infura/networks/near                         |
-| [https://rpc.dev.gateway.fm/v1/near/](./)     | Gateway.fm | https://gateway.fm/                                                 |
-| [https://rpc.ankr.com/near](./)               | ankr.com   | https://www.ankr.com/docs/build-blockchain/chains/v2/near/          |
-| [https://public-rpc.blockpi.io/http/near](./) | BlockPi    | https://chains.blockpi.io/#/near                                    |
+| `https://rpc.mainnet.near.org`            | NEAR       | [You are there!](setup.md)                                          |
+| `https://near-mainnet.api.pagoda.co/rpc/v1`      | Pagoda     | https://www.pagoda.co/console                                       |
+| `https://near-mainnet.infura.io/v3/`      | Infura     | https://docs.infura.io/infura/networks/near                         |
+| `https://rpc.dev.gateway.fm/v1/near/`     | Gateway.fm | https://gateway.fm/                                                 |
+| `https://rpc.ankr.com/near`               | ankr.com   | https://www.ankr.com/docs/build-blockchain/chains/v2/near/          |
+| `https://public-rpc.blockpi.io/http/near` | BlockPi    | https://chains.blockpi.io/#/near                                    |
 | -                                       | figment.io | https://docs.figment.io/guides/staking-api/Near/delegate/ |
 | -                                       | Chainstack | https://chainstack.com/build-better-with-near/            |
-| [https://near-mainnet-rpc.allthatnode.com:3030](./) | All That Node | https://docs.allthatnode.com/protocols/near/          |
+| `https://near-mainnet-rpc.allthatnode.com:3030` | All That Node | https://docs.allthatnode.com/protocols/near/          |

--- a/docs/6.integrator/faq.md
+++ b/docs/6.integrator/faq.md
@@ -34,7 +34,7 @@ Our plan is to have a transparent Bug Bounty program with clear guidelines for p
 
 ### What contracts should we be aware of right now? {#what-contracts-should-we-be-aware-of-right-now}
 
-We have developed a number of [initial contracts](https://github.com/near/initial-contracts) with **ones in bold** being most mature at time of writing
+We have developed a number of [initial contracts](https://github.com/near/core-contracts) with **ones in bold** being most mature at time of writing
 
 - **Staking Pool / Delegation contract**
 - **Lockup / Vesting contract**
@@ -134,13 +134,13 @@ See `nearcore/scripts/nodelib.py` for different examples of configuration.
 
 - MainNet
   - https://explorer.mainnet.near.org (also https://explorer.near.org)
-  - [https://rpc.mainnet.near.org/status](./)
+  - https://rpc.mainnet.near.org/status
 - TestNet
   - https://explorer.testnet.near.org
-  - [https://rpc.testnet.near.org/status](./)
+  - https://rpc.testnet.near.org/status
 - BetaNet
   - https://explorer.betanet.near.org
-  - [https://rpc.betanet.near.org/status](./)
+  - https://rpc.betanet.near.org/status
 
 ### How old can the referenced block hash be before it's invalid? {#how-old-can-the-referenced-block-hash-be-before-its-invalid}
 


### PR DESCRIPTION
Resolves #1249.

Direct Links to changes

- https://near-docs-pr-1250.onrender.com/concepts/basics/networks#mainnet
- https://near-docs-pr-1250.onrender.com/api/rpc/providers
- https://near-docs-pr-1250.onrender.com/integrator/faq#what-is-the-source-of-truth-for-current-block-height-exposed-via-api