### PR TITLE
Fix Broken Links

### DIFF
--- a/docs/1.concepts/basics/networks.md
+++ b/docs/1.concepts/basics/networks.md
@@ -16,7 +16,7 @@ NEAR Protocol operates on several networks each operating with their own indepen
 
 `mainnet` is for production ready smart contracts and live token transfers. Contracts ready for `mainnet` should have gone through rigorous testing and independent security reviews if necessary. `mainnet` is the only network where state is guaranteed to persist over time _(subject to the typical security guarantees of the network's validation process)_.
 
-* [ [Status](https://rpc.mainnet.near.org/status) ]
+* Status: `https://rpc.mainnet.near.org/status`
 * [ [Explorer](https://explorer.near.org) ]
 * [ [Wallet](https://wallet.near.org) ]
 * [ [Data Snapshots](https://near-nodes.io/intro/node-data-snapshots) ]
@@ -26,7 +26,7 @@ NEAR Protocol operates on several networks each operating with their own indepen
 
 `testnet` is a public network and the final testing network for `nearcore` changes before deployment to `mainnet`. `testnet` is intended for testing all aspects of the NEAR platform prior to `mainnet` deployment. From account creation, mock token transfers, development tooling, and smart contract development, the `testnet` environment closely resembles `mainnet` behavior. All `nearcore` changes are deployed as release candidates on first testnet, before the changes are released on `mainnet`. A number of `testnet` validators validate transactions and create new blocks. dApp developers deploy their applications on `testnet` before deploying on `mainnet`. It is important to note that `testnet` has its own transactions and states.
 
-* [ [Status](https://rpc.testnet.near.org/status) ]
+* Status: `https://rpc.testnet.near.org/status`
 * [ [Explorer](https://explorer.testnet.near.org) ]
 * [ [Wallet](https://wallet.testnet.near.org) ]
 * [ [Data Snapshots](https://near-nodes.io/intro/node-data-snapshots) ]
@@ -36,7 +36,7 @@ NEAR Protocol operates on several networks each operating with their own indepen
 
 `betanet` is a public network, where `nearcore` is run to test its stability and backward compatibility. Validators on `betanet` are participants in the Betanet Analysis Group, where they engage in active discussions, submit bug reports, and participate in issue resolution. On `betanet` protocol changes, there are automated hard forks, where the state is compressed into a new genesis. As such, new genesis exists frequently on `betanet`, and there are no historical data snapshots. `betanet` usually has daily releases with protocol features that are not yet stabilized. State is maintained as much as possible but there is no guarantees with its high volatility.
 
-* [ [Status](https://rpc.betanet.near.org/status) ]
+* Status: `https://rpc.betanet.near.org/status`
 * [ [Wallet](https://wallet.betanet.near.org) ]
 
 

--- a/docs/3.tutorials/crosswords/01-basics/01-set-up-skeleton.md
+++ b/docs/3.tutorials/crosswords/01-basics/01-set-up-skeleton.md
@@ -20,7 +20,7 @@ When you created your NEAR testnet account, a private key was created and placed
 
 We'll want to use a command-line interface (CLI) tool to deploy a contract, but at the moment the private key only exists in the browser. Next we'll _add a new key_ to the testnet account and have this stored locally on our computer as a JSON file. (Yes, you can have multiple keys on your NEAR account, which is quite powerful!)
 
-Let's install NEAR CLI. (Please ensure you [have NodeJS](https://nodejs.org/en/download/package-manager) > 12.)
+Let's install NEAR CLI. (Please ensure you [have NodeJS](https://nodejs.org/) > 12.)
 
     npm install -g near-cli
 
@@ -46,7 +46,7 @@ You can see the keys associated with your account by running following command, 
 
 ## Setting up Rust
 
-You may have found the [online Rust Book](https://doc.rust-lang.org/stable/book), which is a great resource for getting started with Rust. However, there are key items that are different when it comes to blockchain development. Namely, that smart contracts are [technically libraries and not binaries](https://learning-rust.github.io/docs/a4.cargo,crates_and_basic_project_structure.html#Crate), but for now just know that we won't be using some commands commonly found in the Rust Book.
+You may have found the [online Rust Book](https://doc.rust-lang.org/stable/book), which is a great resource for getting started with Rust. However, there are key items that are different when it comes to blockchain development. Namely, that smart contracts are [technically libraries and not binaries](https://learning-rust.github.io/docs/cargo-crates-and-basic-project-structure/), but for now just know that we won't be using some commands commonly found in the Rust Book.
 
 :::caution We won't be using
     cargo run

--- a/docs/5.api/rpc/providers.md
+++ b/docs/5.api/rpc/providers.md
@@ -16,6 +16,6 @@ balancing.
 | `https://rpc.dev.gateway.fm/v1/near/`     | Gateway.fm | https://gateway.fm/                                                 |
 | `https://rpc.ankr.com/near`               | ankr.com   | https://www.ankr.com/docs/build-blockchain/chains/v2/near/          |
 | `https://public-rpc.blockpi.io/http/near` | BlockPi    | https://chains.blockpi.io/#/near                                    |
-| -                                       | figment.io | https://docs.figment.io/guides/staking-api/Near/delegate/ |
+| -                                       | figment.io | https://docs.figment.io/guides/staking-api/near/delegate/ |
 | -                                       | Chainstack | https://chainstack.com/build-better-with-near/            |
 | `https://near-mainnet-rpc.allthatnode.com:3030` | All That Node | https://docs.allthatnode.com/protocols/near/          |

--- a/docs/6.integrator/faq.md
+++ b/docs/6.integrator/faq.md
@@ -134,13 +134,13 @@ See `nearcore/scripts/nodelib.py` for different examples of configuration.
 
 - MainNet
   - https://explorer.mainnet.near.org (also https://explorer.near.org)
-  - https://rpc.mainnet.near.org/status
+  - `https://rpc.mainnet.near.org/status`
 - TestNet
   - https://explorer.testnet.near.org
-  - https://rpc.testnet.near.org/status
+  - `https://rpc.testnet.near.org/status` 
 - BetaNet
   - https://explorer.betanet.near.org
-  - https://rpc.betanet.near.org/status
+  - `https://rpc.betanet.near.org/status`
 
 ### How old can the referenced block hash be before it's invalid? {#how-old-can-the-referenced-block-hash-be-before-its-invalid}
 


### PR DESCRIPTION
This PR fixes broken links introduced by https://github.com/near/docs/pull/1245

This PR also changes RPC URLs in docs to `code commented` URLs as to avoid CI failure when services as RPC Betanet are offline