### PR TITLE
Suggestion for changing the menu

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,7 +116,7 @@ module.exports = {
         },
         {
           to: "/tutorials/welcome",
-          label: "📚 Tutorials",
+          label: "📚 Examples & Tutorials",
           position: "left",
         },
         {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -92,11 +92,6 @@
     },
     "develop/quickstart-guide",
     {
-      "type": "doc",
-      "id": "tutorials/welcome",
-      "label": "Examples & Tutorials ↗"
-    },
-    {
       "Develop a Contract": [
         "develop/contracts/whatisacontract",
         {
@@ -219,11 +214,6 @@
       "Finance": [
         {
           "type": "link",
-          "label": "🌈 Rainbow Bridge",
-          "href": "https://rainbowbridge.app/transfer"
-        },
-        {
-          "type": "link",
           "label": "💱 Fiat On-Ramp",
           "href": "https://awesomenear.com/categories/payments"
         },
@@ -250,12 +240,17 @@
     },
     {
       "type": "html",
-      "value": "<span class='menu__link'><b><small> Virtual Machines </small></b></span>"
+      "value": "<span class='menu__link'><b><small> Ethereum Ecosystem </small></b></span>"
     },
     {
       "type": "link",
       "label": "Aurora (EVM)",
       "href": "https://aurora.dev"
+    },
+    {
+      "type": "link",
+      "label": "Rainbow Bridge",
+      "href": "https://rainbowbridge.app/transfer"
     },
     {
       "type": "html",


### PR DESCRIPTION
I decluttered a bit the menu:
- Renamed the top-bar "Tutorials" to "Tutorials and Examples"
- Removed the "tutorials and examples" link from the Develop Section
- Moved all Ethereal related stuff to its own section in the menu

This is simply a proposal, and as such it can be easily rejected.