### PR TITLE
fix: cross contract call snippet used wrong code

### DIFF
--- a/docs/2.develop/contracts/crosscontract.md
+++ b/docs/2.develop/contracts/crosscontract.md
@@ -60,7 +60,7 @@ Calling another contract passing information is also a common scenario. Bellow y
   <Language value="🦀 Rust" language="rust">
     <Github fname="lib.rs"
             url="https://github.com/near-examples/cross-contract-hello-rust/blob/main/contract/src/lib.rs"
-            start="38" end="62" />
+            start="51" end="75" />
     <Github fname="external.rs"
             url="https://github.com/near-examples/cross-contract-hello-rust/blob/main/contract/src/external.rs" />
   </Language>


### PR DESCRIPTION
In the rust code snippet of [sending information](https://docs.near.org/develop/contracts/crosscontract#snippet-sending-information) from one contract to another, doc selected wrong code block from github. It should be `L51-L75` instead to show `change_greeting` and `change_greeting_callback`.

Current doc shows `query_greeting_callback` and `change_greeting`.