### PR TITLE
add alpha status for JS-SDK

### DIFF
--- a/docs/2.develop/contracts/whatiscontract.md
+++ b/docs/2.develop/contracts/whatiscontract.md
@@ -22,6 +22,14 @@ Smart contracts **cannot perform HTTP requests**, meaning they can't retrieve da
 ## Programming Languages
 Developers can choose between using [Javascript](../../4.tools/js-sdk.md) or [Rust](../../4.tools/js-sdk.md) to write smart contracts in NEAR.
 
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+The JavaScript runtime has not been fully audited. For creating smart contracts that hold value please use [`near-sdk-rs`](https://github.com/near/near-sdk-rs). 
+
+:::
+
 Indistinctly from the language chosen, the NEAR SDK will help you to compile the contract into WebAssembly, from which point it can be deployed and executed on the NEAR platform.
 
 

--- a/docs/3.tutorials/nfts/js/0-intro.md
+++ b/docs/3.tutorials/nfts/js/0-intro.md
@@ -7,6 +7,15 @@ sidebar_label: Introduction
 > In this _Zero to Hero_ series, you'll find a set of tutorials that will cover every aspect of a non-fungible token (NFT) smart contract.
 > You'll start by minting an NFT using a pre-deployed contract and by the end you'll end up building a fully-fledged NFT smart contract that supports every extension.
 
+
+:::caution
+ 
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+ 
+The JavaScript runtime has not been fully audited. For creating smart contracts that hold value please use [`near-sdk-rs`](https://github.com/near/near-sdk-rs). 
+ 
+:::
+
 ## Prerequisites
 
 To complete these tutorials successfully, you'll need:

--- a/docs/3.tutorials/nfts/js/0-predeployed.md
+++ b/docs/3.tutorials/nfts/js/0-predeployed.md
@@ -6,6 +6,13 @@ sidebar_label: Pre-deployed Contract
 
 > Learn how to easily create your own non-fungible tokens without doing any software development by using a readily-available NFT smart contract.
 
+
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Prerequisites
 
 To complete this tutorial successfully, you'll need:

--- a/docs/3.tutorials/nfts/js/1-skeleton.md
+++ b/docs/3.tutorials/nfts/js/1-skeleton.md
@@ -7,6 +7,13 @@ sidebar_label: Contract Architecture
 > In this article, you'll learn about the basic architecture behind the NFT contract that you'll develop while following this _"Zero to Hero"_ series.
 > You'll discover the contract's layout and you'll see how the JavaScript files are structured in order to build a feature-complete smart contract.
 
+
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Introduction
 
 This tutorial presents the code skeleton for the NFT smart contract and its file structure.

--- a/docs/3.tutorials/nfts/js/2-minting.md
+++ b/docs/3.tutorials/nfts/js/2-minting.md
@@ -6,6 +6,13 @@ sidebar_label: Minting
 
 This is the first of many tutorials in a series where you'll be creating a complete NFT smart contract from scratch that conforms with all the NEAR [NFT standards](https://nomicon.io/Standards/NonFungibleToken/). Today you'll learn how to create the logic needed to mint NFTs and have them show up in your NEAR wallet. You will be modifying a bare-bones [skeleton smart contract](/tutorials/nfts/js/skeleton) by filling in the necessary code snippets needed to add minting functionalities.
 
+
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Introduction
 
 To get started, switch to the `1.skeleton` branch in our repo. If you haven't cloned the repository, refer to the [Contract Architecture](/tutorials/nfts/js/skeleton) to get started.

--- a/docs/3.tutorials/nfts/js/2-upgrade.md
+++ b/docs/3.tutorials/nfts/js/2-upgrade.md
@@ -6,6 +6,13 @@ sidebar_label: Upgrade a Contract
 
 In this tutorial, you'll build off the work you previously did to implement the [minting functionality](/tutorials/nfts/js/minting) on a skeleton smart contract. You got to the point where NFTs could be minted, however, the wallet had no way of displaying the tokens since your contract didn't implement the method that the wallet was trying to call.
 
+
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Introduction
 
 Today you'll learn about deploying patch fixes to smart contracts and you'll use that knowledge to implement the `nft_tokens_for_owner` function on the contract you deployed in the previous tutorial.

--- a/docs/3.tutorials/nfts/js/3-enumeration.md
+++ b/docs/3.tutorials/nfts/js/3-enumeration.md
@@ -7,6 +7,13 @@ sidebar_label: Enumeration
 In the previous tutorials, you looked at ways to integrate the minting functionality into a skeleton smart contract. In order to get your NFTs to show in the wallet, you also had to deploy a patch fix that implemented one of the enumeration methods. In this tutorial, you'll expand on and finish the rest of the enumeration methods as per the [standard](https://nomicon.io/Standards/NonFungibleToken/Enumeration.html)
 Now you'll extend the NFT smart contract and add a couple of enumeration methods that can be used to return the contract's state.
 
+
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Introduction
 
 As mentioned in the [Upgrade a Contract](/tutorials/nfts/js/upgrade-contract/) tutorial, you can deploy patches and fixes to smart contracts. This time, you'll use that knowledge to implement the `nft_total_supply`, `nft_tokens` and `nft_supply_for_owner` enumeration functions.

--- a/docs/3.tutorials/nfts/js/4-core.md
+++ b/docs/3.tutorials/nfts/js/4-core.md
@@ -6,6 +6,13 @@ sidebar_label: Core
 
 In this tutorial you'll learn how to implement the [core standards](https://nomicon.io/Standards/NonFungibleToken/Core.html) into your smart contract. If you're joining us for the first time, feel free to clone [this repo](https://github.com/near-examples/nft-tutorial) and checkout the `3.enumeration` branch to follow along.
 
+
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ```bash
 git checkout 3.enumeration
 ```

--- a/docs/3.tutorials/nfts/js/5-approval.md
+++ b/docs/3.tutorials/nfts/js/5-approval.md
@@ -6,6 +6,12 @@ sidebar_label: Approvals
 
 In this tutorial you'll learn the basics of an approval management system which will allow you to grant others access to transfer NFTs on your behalf. This is the backbone of all NFT marketplaces and allows for some complex yet beautiful scenarios to happen. If you're joining us for the first time, feel free to clone [this repository](https://github.com/near-examples/nft-tutorial) and checkout the `4.core` branch to follow along.
 
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 
 ```bash
 git checkout 4.core

--- a/docs/3.tutorials/nfts/js/6-royalty.md
+++ b/docs/3.tutorials/nfts/js/6-royalty.md
@@ -6,6 +6,12 @@ sidebar_label: Royalty
 
 In this tutorial you'll continue building your non-fungible token (NFT) smart contract, and learn how to implement perpetual royalties into your NFTs. This will allow people to get a percentage of the purchase price when an NFT is sold.
 
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Introduction
 
 By now, you should have a fully fledged NFT contract, except for the royalties support.

--- a/docs/3.tutorials/nfts/js/7-events.md
+++ b/docs/3.tutorials/nfts/js/7-events.md
@@ -6,6 +6,12 @@ sidebar_label: Events
 
 In this tutorial, you'll learn about the [events standard](https://nomicon.io/Standards/NonFungibleToken/Event.html) and how to implement it in your smart contract.
 
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Introduction
 
 To get started, either switch to the `6.royalty` branch from our [GitHub repository](https://github.com/near-examples/nft-tutorial/), or continue your work from the previous tutorials.

--- a/docs/3.tutorials/nfts/js/8-marketplace.md
+++ b/docs/3.tutorials/nfts/js/8-marketplace.md
@@ -6,6 +6,12 @@ sidebar_label: Marketplace
 
 In this tutorial, you'll learn the basics of an NFT marketplace contract where you can buy and sell non-fungible tokens for $NEAR. In the previous tutorials, you went through and created a fully fledged NFT contract that incorporates all the standards found in the [NFT standard](https://nomicon.io/Standards/NonFungibleToken). 
 
+:::caution
+
+The JS-SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+
+:::
+
 ## Introduction
 
 Throughout this tutorial, you'll learn how a marketplace contract could work on NEAR. This is meant to be an example and there is no canonical implementation. Feel free to branch off and modify this contract to meet your specific needs.

--- a/docs/4.tools/js-sdk.md
+++ b/docs/4.tools/js-sdk.md
@@ -5,6 +5,19 @@ title: JavaScript SDK
 
 JavaScript is the most popular programming language, used by nearly 14 million developers worldwide. You can write smart-contracts in JavaScript or Typescript, and our SDK will pack them with a lightweight runtime. This can then be compiled into a single Wasm file that can be deployed into the NEAR network.
 
+:::caution
+ 
+This SDK is currently in **[`Alpha`](https://github.com/near/near-sdk-js/releases/)**. 
+ 
+The JavaScript runtime has not been fully audited. For creating smart contracts that hold value please use [`near-sdk-rs`](https://github.com/near/near-sdk-rs). 
+ 
+Help contribute!
+- [Report issues you encounter](https://github.com/near/near-sdk-js/issues) 🐞 
+- [Provide suggestions or feedback](https://github.com/near/near-sdk-js/discussions) 💡 
+- [Show us what you've built!](https://github.com/near/near-sdk-js/discussions/categories/show-and-tell) 💪  
+
+:::
+
 ---
 
 ## Create Your First Javascript Contract


### PR DESCRIPTION
JS SDK is currently in `alpha` and a warning should be added to docs to clearly communicate this as mentioned in this PR:

https://github.com/near/near-sdk-js/pull/298
