### PR TITLE
docs: fixed grammar in contacts/actions

### DIFF
--- a/docs/2.develop/contracts/actions.md
+++ b/docs/2.develop/contracts/actions.md
@@ -19,7 +19,7 @@ but **cannot** call two methods on different contracts.
 
 ## Transfer NEAR Ⓝ
 
-You can send $NEAR from the your contract to any other account on the network. The Gas cost for transferring $NEAR is fixed and is based on the protocol's genesis config. Currently, it costs `~0.45 TGas`.
+You can send $NEAR from your contract to any other account on the network. The Gas cost for transferring $NEAR is fixed and is based on the protocol's genesis config. Currently, it costs `~0.45 TGas`.
 
 <Tabs className="language-tabs" groupId="code-tabs">
   <TabItem value="🌐 JavaScript">


### PR DESCRIPTION
Updated "You can send $NEAR from the your contract to any other account on the network" to "You can send $NEAR from your contract to any other account on the network".