### PR TITLE
Update escrow.md

### DIFF
--- a/docs/3.tutorials/examples/escrow.md
+++ b/docs/3.tutorials/examples/escrow.md
@@ -101,7 +101,7 @@ near view <your-assets-testnet-account-id> get_account_assets '{"account_id": "<
 You may also check the NEAR balance of the seller account, making sure they have not received the payment yet:
 
 ```bash
-near state <seller-account-id>
+near state <your-asset-owner-account-id>
 ```
 
 #### 5. Approve the Purchase


### PR DESCRIPTION
The `near state` on a different account ID than the one on previous commands was confusing. This PR fixes this. Mentioned in Stack Overflow here: https://stackoverflow.com/questions/74722681/near-smart-contract-obscure-instructions-in-the-documentation