### PR TITLE
Update credentials.md with info about env vars

### DIFF
--- a/docs/3.tutorials/indexer/credentials.md
+++ b/docs/3.tutorials/indexer/credentials.md
@@ -29,3 +29,13 @@ aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
 [AWS docs: Configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+
+#### Environment varibales
+
+Alternatively, you can provide your AWS credentials via environment variables with constant names:
+
+```
+$ export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+$ AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+$ AWS_DEFAULT_REGION=eu-central-1
+```


### PR DESCRIPTION
This change adds an additional section to the https://docs.near.org/tutorials/indexer/credentials#aws-s3-credentials document with the info about the usage of environment variables as an alternative to `.aws/credentials` file