### PR TITLE
Update 1RPC endpoint

### DIFF
--- a/docs/5.api/rpc/providers.md
+++ b/docs/5.api/rpc/providers.md
@@ -23,3 +23,4 @@ balancing.
 | `https://getblock.io/nodes/near/` | GetBlock | https://getblock.io/nodes/near/         |
 | `http://bit.do/freeapikey-near` | NOWNodes |    https://nownodes.io/     |
 | `https://endpoints.omniatech.io/v1/near/mainnet/public` | OMNIA | https://omniatech.io |
+| `https://1rpc.io/near` | 1RPC | https://docs.ata.network/1rpc/introduction/#overview |


### PR DESCRIPTION
1RPC is a private RPC relay that's officially supported by Near.