### PR TITLE
Updated NEAR SDK JS docs

### DIFF
--- a/docs/2.develop/contracts/crosscontract.md
+++ b/docs/2.develop/contracts/crosscontract.md
@@ -84,7 +84,7 @@ Both promises take the same arguments:
 <CodeTabs>
   <Language value="🌐 JavaScript" language="ts">
     <CodeBlock>
-    NearPromise.new("external_address").functionCall("method", bytes(JSON.stringify(arguments)), DEPOSIT, GAS);
+    NearPromise.new("external_address").functionCall("method", JSON.stringify(arguments), DEPOSIT, GAS);
     </CodeBlock>
   </Language>
   <Language value="🦀 Rust" language="rust">


### PR DESCRIPTION
The new release of near-sdk-js (0.7) changes how promises are built.