### PR TITLE
Bump tsconfig lib target to ES2018

### DIFF
--- a/docs/3.tutorials/indexer/js-lake-indexer.md
+++ b/docs/3.tutorials/indexer/js-lake-indexer.md
@@ -93,7 +93,7 @@ Paste the content to the file:
 {
   "compilerOptions": {
     "lib": [
-      "ES2015",
+      "ES2018",
       "dom"
     ]
   }


### PR DESCRIPTION
ES2015 would generate the following error: 

```bash
npm run start

> near-lake-raw-printer-js@1.0.0 start
> tsc && node index.js

node_modules/@aws-sdk/types/dist-types/eventStream.d.ts:66:90 - error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.

66     <T>(body: StreamType, deserializer: (input: Record<string, Message>) => Promise<T>): AsyncIterable<T>;
                                                                                            ~~~~~~~~~~~~~

node_modules/@aws-sdk/types/dist-types/eventStream.d.ts:72:16 - error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.

72     <T>(input: AsyncIterable<T>, serializer: (event: T) => Message): StreamType;
                  ~~~~~~~~~~~~~

node_modules/@aws-sdk/types/dist-types/pagination.d.ts:5:36 - error TS2583: Cannot find name 'AsyncGenerator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.

5 export declare type Paginator<T> = AsyncGenerator<T, T, unknown>;
                                     ~~~~~~~~~~~~~~

node_modules/near-lake-framework/dist/streamer.d.ts:2:53 - error TS2583: Cannot find name 'AsyncIterableIterator'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.

2 export declare function stream(config: LakeConfig): AsyncIterableIterator<StreamerMessage>;
                                                      ~~~~~~~~~~~~~~~~~~~~~


Found 4 errors in 3 files.

Errors  Files
     2  node_modules/@aws-sdk/types/dist-types/eventStream.d.ts:66
     1  node_modules/@aws-sdk/types/dist-types/pagination.d.ts:5
     1  node_modules/near-lake-framework/dist/streamer.d.ts:2
```