### PR TITLE
update RAM requirements for chunk-only producers

### DIFF
--- a/docs/1.concepts/basics/validators.md
+++ b/docs/1.concepts/basics/validators.md
@@ -46,7 +46,7 @@ You can read more about our consensus strategy on our <a href="https://github.co
 
 The Chunk-Only Producer is a more accessible role with lower hardware and token requirements. This new role will allow the network's validator number to grow, creating more opportunities to earn rewards and secure the NEAR Ecosystem. 
 
-[Chunk-Only Producers](https://near.org/papers/the-official-near-white-paper/#economics) are solely responsible for [producing chunks](https://near.org/papers/nightshade/#nightshade) (parts of the block from a shard, see [Nightshade](https://near.org/papers/nightshade/) for more detail) in one shard (a partition on the network). Because Chunk-Only Producers only need to validate one shard, they can run the validator node on a 4-Core CPU, with 8GB of RAM, and 200 GB SSD of storage.
+[Chunk-Only Producers](https://near.org/papers/the-official-near-white-paper/#economics) are solely responsible for [producing chunks](https://near.org/papers/nightshade/#nightshade) (parts of the block from a shard, see [Nightshade](https://near.org/papers/nightshade/) for more detail) in one shard (a partition on the network). Because Chunk-Only Producers only need to validate one shard, they can run the validator node on a 4-Core CPU, with 12GB of RAM, and 200 GB SSD of storage.
 
 Like Validators, Chunk-Only Producers will receive, at minimum, 4.5% annual rewards. If less than 100% of the tokens on the network is staked, Chunk-Only Producers stand to earn even more annual rewards. For more details about the Validator’s economics, please check out [NEAR’s Economics Explained](https://near.org/blog/near-protocol-economics/).
 


### PR DESCRIPTION
This updates the RAM requirements that should have been bumped after 1.28.1, to be consistent with https://github.com/near/node-docs/blob/main/docs/rpc/hardware-rpc.md