### PR TITLE
feat(i18n): enable Korean language

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           cd website && yarn
           yarn crowdin:build
-          yarn build --locale zh-CN && yarn build --locale vi && yarn build --locale en
+          yarn build --locale zh-CN && yarn build --locale vi && yarn build --locale ko && yarn build --locale en
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -187,7 +187,7 @@ module.exports = {
   },
   i18n: {
     defaultLocale: "en",
-    locales: ["en", "vi", "zh-CN"],
+    locales: ["en", "ko", "vi", "zh-CN"],
     localeConfigs: {
       "zh-CN": {
         label: "简体中文",


### PR DESCRIPTION
This is to enable Korean language on docs as the NEAR Korea Hub has almost finished translating all the docs on https://docs.near.org.

A few errors about the Korean translation have been fixed: https://hackmd.io/@L9ZnGph8Tbaio2GVX_z-EA/B1-95HBfn

Let's do more testing before merge this into production. 
