### PR TITLE
chore: build all locales together by increasing node memory limit

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -23,10 +23,6 @@ jobs:
           cd website && yarn
           yarn crowdin:build
           yarn build
-        # yarn build --locale en --out-dir build \
-        #   && yarn build --locale ko --out-dir ko \
-        #   && yarn build --locale vi --out-dir vi \
-        #   && yarn build --locale zh-CN --out-dir zh-CN
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -29,3 +29,4 @@ jobs:
         #   && yarn build --locale zh-CN --out-dir zh-CN
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -22,6 +22,10 @@ jobs:
         run: |
           cd website && yarn
           yarn crowdin:build
-          yarn build --locale zh-CN && yarn build --locale vi && yarn build --locale ko && yarn build --locale en
+          yarn build
+        # yarn build --locale en --out-dir build \
+        #   && yarn build --locale ko --out-dir ko \
+        #   && yarn build --locale vi --out-dir vi \
+        #   && yarn build --locale zh-CN --out-dir zh-CN
         env:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
This fixes the 404 error when opening pages in non-English languages such as https://docs.near.org/zh-CN/develop/welcome. 

The cause of the error is, by using the current command `yarn build --locale zh-CN && yarn build --locale vi && yarn build --locale ko && yarn build --locale en`, the last step `yarn build --locale en` will overwrite the static files of other languages, and the subfolder `vi`, `zh-CN` , `ko` are omitted if building with the locale flag. So the paths such as `zh-CN/develop/welcome` don't exist. 

----

The reason that we could not use `yarn build` command (without `locale` flag) previously is because we'd encounter the error `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` when building docs for all languages. The memory usage increases either because we have too many files, or there're some very large files, which needs to determined by more investigation. 

We can workaround the error by setting environment variable `NODE_OPTIONS=--max-old-space-size=8192` in GitHub actions and Render. I have tested and this works for both GitHub actions and my Render preview: https://near-docs-i18n.onrender.com

In the meanwhile, we should remove some of the deprecated source files from Crowdin project to reduce building time and memory usage. Will work on this later. 