### PR TITLE
Fix docs infiniteScroll.md not showing

### DIFF
--- a/docs/bos/components/infiniteScroll.md
+++ b/docs/bos/components/infiniteScroll.md
@@ -41,7 +41,7 @@ return (
       loadMore={loadNumbers}
       hasMore={state.displayNums.length < allNumbers.length}
     >
-      {state.displayNums}
+      <p>{state.displayNums}</p>
     </InfiniteScroll>
   </div>
 );
@@ -106,7 +106,7 @@ return (
       loadMore={makeMoreMemes}
       hasMore={state.widgets.length < state.allMemes.length}
     >
-      {state.widgets}
+      <div>{state.widgets}</div>
     </InfiniteScroll>
   </div>
 );


### PR DESCRIPTION
During my Encode x Aurora hack I found this bug on the documentation.

# Before
<img width="975" alt="Screenshot_2023_06_25_At_11 37 17" src="https://github.com/near/docs/assets/11813607/1f34cd33-4234-4cb1-bdd4-aff3cae305fe">
<img width="1005" alt="Screenshot_2023_06_25_At_11 37 14" src="https://github.com/near/docs/assets/11813607/9ca6c608-99bd-46bb-8ffe-1e219f4d8756">


# After
<img width="954" alt="Screenshot_2023_06_25_At_11 37 39" src="https://github.com/near/docs/assets/11813607/e7fd49c6-6067-4547-8851-e8a752f8bd4f">
<img width="961" alt="Screenshot_2023_06_25_At_11 37 35" src="https://github.com/near/docs/assets/11813607/3287971c-f712-4875-a2d0-c7884bc7b0ed">

