### PR TITLE
Added Tabs for  both  near-cli-rs  and  near-cli  commands 

### DIFF
--- a/docs/2.develop/deploy.md
+++ b/docs/2.develop/deploy.md
@@ -24,6 +24,11 @@ Thanks to the `NEAR CLI` deploying a contract is as simple as:
 2. Deploy it into the desired account using the [NEAR CLI](../4.tools/cli.md#near-deploy):
 
 #### Create an Account and Deploy
+
+
+<Tabs className="language-tabs" groupId="code-tabs">
+  <TabItem value="Near-CLI">
+
 ```bash
 # Automatically deploy the wasm in a new account
 near dev-deploy <route_to_wasm>
@@ -32,7 +37,36 @@ near dev-deploy <route_to_wasm>
 cat ./neardev/dev-account
 ```
 
+  </TabItem>
+  <TabItem value="Near-CLI-rs">
+
+```bash
+# Automatically deploy the wasm in a new account
+near account create-account sponsor-by-faucet-service <my-new-dev-account>.testnet autogenerate-new-keypair save-to-keychain network-config testnet create
+
+
+near contract deploy <my-new-dev-account>.testnet use-file <route_to_wasm> without-init-call network-config testnet sign-with-keychain
+```
+
+  </TabItem>
+</Tabs>
+
+
+
+
+
+
+
+
+
+
 #### Deploy in an Existing Account
+
+<Tabs className="language-tabs" groupId="code-tabs">
+  <TabItem value="Near-CLI">
+
+
+
 ```bash
 # login into your account
 near login
@@ -40,6 +74,24 @@ near login
 # deploy the contract
 near deploy <accountId> <route_to_wasm>
 ```
+
+  </TabItem>
+  <TabItem value="Near-CLI-rs">
+
+```bash
+# login into your account
+near account import-account using-web-wallet network-config testnet
+
+# deploy the contract
+near contract deploy <accountId> use-file <route_to_wasm> without-init-call network-config testnet sign-with-keychain send
+
+```
+
+  </TabItem>
+</Tabs>
+
+
+
 
 :::tip
 You can overwrite a contract by deploying another on top of it. In this case, the account's logic
@@ -62,10 +114,29 @@ Considering this, we advise to name methods using `snake_case` in all SDKs as th
 If your contract has an [initialization method](./contracts/anatomy.md#initialization-functions) you can call it to
 initialize the state. This is not necessary if your contract implements `default` values for the state. 
 
+
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
 ```bash
 # Call the initialization method (`init` in our examples)
 near call <contractId> <initMethod> [<args>] --accountId <accountId>
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+
+```bash
+# Call the initialization method (`init` in our examples)
+near contract call-function as-transaction <contractId> <initMethod> json-args [<args>] prepaid-gas '30 TeraGas' attached-deposit '0 NEAR' sign-as <accountId> network-config testnet sign-with-keychain send
+```
+
+</TabItem>
+</Tabs>
+
+
+
 
 :::info
 You can initialize your contract [during deployment](#deploying-the-contract) using the `--initFunction` & `--initArgs` arguments.
@@ -81,9 +152,25 @@ Once your contract is deployed you can interact with it right away using [NEAR C
 ### View methods
 View methods are those that perform **read-only** operations. Calling these methods is free, and do not require to specify which account is being used to make the call:
 
+
+
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+  
 ```bash
 near view <contractId> <methodName>
 ```
+
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash
+near contract call-function as-read-only <contractId> <methodName> text-args '' network-config testnet now
+```
+</TabItem>
+</Tabs>
+
 
 :::tip
 View methods have by default 200 TGAS for execution
@@ -95,6 +182,21 @@ View methods have by default 200 TGAS for execution
 Change methods are those that perform both read and write operations. For these methods we do need to specify the account being used to make the call,
 since that account will expend GAS in the call.
 
+
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+  
 ```bash
 near call <contractId> <methodName> <jsonArgs> --accountId <yourAccount> [--deposit <amount>] [--gas <GAS>]
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+  
+```bash
+near contract call-function as-transaction <AccountId> <MethodName> json-args <JsonArgs> prepaid-gas <PrepaidGas> attached-deposit <AttachedDeposit> sign-as <AccountId>  network-config testnet sign-with-keychain send
+```
+</TabItem>
+</Tabs>
+
+

--- a/docs/2.develop/lock.md
+++ b/docs/2.develop/lock.md
@@ -8,12 +8,39 @@ Removing all [full access keys](../4.tools/cli.md#near-delete-key-near-delete-ke
 When an account is locked nobody can perform transactions in the account's name (e.g. update the code or transfer money).
 
 #### How to Lock an Account
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
 ```bash
 near keys <dev-account>
 # result: [access_key: {"nonce": ..., "public_key": '<key>'}]
 
 near delete-key <dev-account> '<key>'
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash
+near account list-keys <dev-account> network-config testnet now
+# result:
+
++---+------------+-------+-------------+
+| # | Public Key | Nonce | Permissions |
++---+------------+-------+-------------+
+  ..    '<key>'      ...        ...
++---+------------+-------+-------------+
+
+near account delete-key <dev-account> '<key>' network-config testnet sign-with-keychain send
+
+```
+
+
+
+</TabItem>
+</Tabs>
+
+
+
 
 #### Why Locking an Account
 Locking an account brings more reassurance to end-users, since they know no external actor will be able to manipulate the account's

--- a/docs/2.develop/upgrade.md
+++ b/docs/2.develop/upgrade.md
@@ -20,6 +20,10 @@ Contract's can be updated in two ways:
 ## Updating Through Tools
 Simply re-deploy another contract using your preferred tool, for example, using [NEAR CLI](../4.tools/cli.md):
 
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
 ```bash
 # If you already used dev-deploy the same account will be used
 near dev-deploy --wasmFile <new-contract>
@@ -27,6 +31,28 @@ near dev-deploy --wasmFile <new-contract>
 # If you logged in
 near deploy <account-id> --wasmFile <new-contract>
 ```
+
+
+
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+
+```bash
+# If you already used dev-deploy the same account will be used
+near contract deploy <my-new-dev-account>.testnet use-file <route_to_wasm> without-init-call network-config testnet sign-with-keychain
+
+
+# If you logged in
+near contract deploy <accountId> use-file <route_to_wasm> without-init-call network-config testnet sign-with-keychain send
+
+```
+
+
+</TabItem>
+</Tabs>
+
+
 
 ---
 

--- a/docs/sdk/js/building/prototyping.md
+++ b/docs/sdk/js/building/prototyping.md
@@ -32,10 +32,32 @@ For both cases, let's consider the following example.
 
 Let's say you deploy [a JS status message contract](https://github.com/near/near-sdk-js/blob/263c9695ab7bb853ced12886c4b3f8663070d900/examples/src/status-message-collections.js#L10-L42) contract to testnet, then call it with:
 
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+    
 ```bash
 near call [contract] set_status '{"message": "lol"}' --accountId you.testnet
 near view [contract] get_status '{"account_id": "you.testnet"}'
 ```
+
+</TabItem>
+<TabItem value="Near-CLI-rs">
+    
+```bash
+near contract call-function as-transaction [contract] set_status json-args '{"message": "lol"}' prepaid-gas '30 TeraGas' attached-deposit '0 NEAR' sign-as you.testnet network-config testnet sign-with-keychain send
+
+near contract call-function as-read-only [contract] get_status text-args '{"account_id": "you.testnet"}' network-config testnet now
+```
+</TabItem>
+</Tabs>
+
+
+
+
+
+
+
+
 
 This will return the message that you set with the call to `set_status`, in this case `"lol"`.
 
@@ -49,9 +71,34 @@ You build & deploy the contract again, thinking that maybe because the new `tagl
 
 When first getting started with a new project, the fastest way to deploy a contract is [`dev-deploy`](/concepts/basics/accounts/creating-accounts):
 
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
 ```bash
 near dev-deploy [--wasmFile ./path/to/compiled.wasm]
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash
+near account create-account sponsor-by-faucet-service <my-new-dev-account>.testnet autogenerate-new-keypair save-to-keychain network-config testnet create
+
+near contract deploy <my-new-dev-account>.testnet use-file <route_to_wasm> without-init-call network-config testnet sign-with-keychain
+
+```
+
+
+
+</TabItem>
+</Tabs>
+
+
+
+
+
+
+
 
 This does a few things:
 
@@ -69,22 +116,69 @@ The easiest way is just to delete the `neardev` folder, then run `near dev-deplo
 ### 2. Deleting & recreating contract account
 
 If you want to have a predictable account name rather than an ever-changing `dev-*` account, the best way is probably to create a sub-account:
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
 
 ```bash title="Create sub-account"
 near create-account app-name.you.testnet --masterAccount you.testnet
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash title="Create sub-account"
+near account create-account fund-myself app-name.you.testnet '100 NEAR' autogenerate-new-keypair save-to-keychain sign-as you.testnet network-config testnet sign-with-keychain send
+```
+    
+</TabItem>
+</Tabs>
+
+
+
 
 Then deploy your contract to it:
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
 
 ```bash title="Deploy to sub-account"
 near deploy --accountId app-name.you.testnet [--wasmFile ./path/to/compiled.wasm]
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash title="Deploy to sub-account"
+near contract deploy app-name.you.testnet use-file <./path/to/compiled.wasm> without-init-call network-config testnet sign-with-keychain send
+```
+    
+</TabItem>
+</Tabs>
+
+
 
 In this case, how do you delete all contract state and start again? Delete the sub-account and recreate it.
 
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+    
 ```bash title="Delete sub-account"
 near delete app-name.you.testnet you.testnet
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+    
+```bash title="Delete sub-account"
+near account delete-account app-name.you.testnet beneficiary you.testnet network-config testnet sign-with-keychain send
+```
+</TabItem>
+</Tabs>
+
+
+
+
+
+
+
+
 
 This sends all funds still on the `app-name.you.testnet` account to `you.testnet` and deletes the contract that had been deployed to it, including all contract state.
 

--- a/docs/sdk/js/promises/token-tx.md
+++ b/docs/sdk/js/promises/token-tx.md
@@ -41,6 +41,27 @@ Most of this is boilerplate you're probably familiar with by now – imports, s
 
 - Returning the `NearPromise`: This allows NEAR Explorer, near-cli, near-api-js, and other tooling to correctly determine if a whole chain of transactions is successful. If your function does not return `Promise`, tools like near-cli will return immediately after your function call. And then even if the `transfer` fails, your function call will be considered successful.
 
-Using near-cli, someone could invoke this function with a call like:
+Using near-cli or near-cli-rs, someone could invoke this function with a call like:
 
-    near call $CONTRACT pay '{"amount": "1000000000000000000000000", "to": "example.near"}' --accountId root.near
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
+
+```bash
+near call <contract> pay '{"amount": "1000000000000000000000000", "to": "example.near"}' --accountId benjiman.near
+```
+
+
+
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash
+near contract call-function as-transaction <contract> pay json-args '{"amount": "1000000000000000000000000", "to": "example.near"}' prepaid-gas '30 TeraGas' attached-deposit '0 NEAR' sign-as benjiman.near network-config testnet sign-with-keychain send
+```
+
+
+
+</TabItem>
+</Tabs>
+

--- a/docs/sdk/rust/building/prototyping.md
+++ b/docs/sdk/rust/building/prototyping.md
@@ -42,11 +42,24 @@ The [rust-status-message](https://github.com/near-examples/rust-status-message) 
 
 Let's say you deploy this contract to testnet, then call it with:
 
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
 ```bash
 near call [contract] set_status '{"message": "lol"}' --accountId you.testnet
 near view [contract] get_status '{"account_id": "you.testnet"}'
 ```
 
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash
+near contract call-function as-transaction [contract] set_status json-args '{"message": "lol"}' prepaid-gas '30 TeraGas' attached-deposit '0 NEAR' sign-as you.testnet network-config testnet sign-with-keychain send
+
+near contract call-function as-read-only [contract] get_status text-args '{"account_id": "you.testnet"}' network-config testnet now
+```
+</TabItem>
+</Tabs>
 This will return the message that you set with the call to `set_status`, in this case `"lol"`.
 
 At this point the contract is deployed and has some state. 
@@ -97,10 +110,26 @@ You build & deploy the contract again, thinking that maybe because the new `tagl
 ### 1. `rm -rf neardev && near dev-deploy`
 
 When first getting started with a new project, the fastest way to deploy a contract is [`dev-deploy`](/concepts/basics/accounts/creating-accounts):
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
 
 ```bash
 near dev-deploy [--wasmFile ./path/to/compiled.wasm]
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash
+near account create-account sponsor-by-faucet-service <my-new-dev-account>.testnet autogenerate-new-keypair save-to-keychain network-config testnet create
+
+near contract deploy <my-new-dev-account>.testnet use-file <route_to_wasm> without-init-call network-config testnet sign-with-keychain
+
+```
+
+
+
+</TabItem>
+</Tabs>
 
 This does a few things:
 
@@ -119,21 +148,58 @@ The easiest way is just to delete the `neardev` folder, then run `near dev-deplo
 
 If you want to have a predictable account name rather than an ever-changing `dev-*` account, the best way is probably to create a sub-account:
 
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
 ```bash title="Create sub-account"
 near create-account app-name.you.testnet --masterAccount you.testnet
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash title="Create sub-account"
+near account create-account fund-myself app-name.you.testnet '100 NEAR' autogenerate-new-keypair save-to-keychain sign-as you.testnet network-config testnet sign-with-keychain send
+```
+
+</TabItem>
+</Tabs>
 
 Then deploy your contract to it:
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
 
 ```bash title="Deploy to sub-account"
 near deploy --accountId app-name.you.testnet [--wasmFile ./path/to/compiled.wasm]
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash title="Deploy to sub-account"
+near contract deploy app-name.you.testnet use-file <./path/to/compiled.wasm> without-init-call network-config testnet sign-with-keychain send
+```
+
+</TabItem>
+</Tabs>
+
 
 In this case, how do you delete all contract state and start again? Delete the sub-account and recreate it.
+
+
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
 
 ```bash title="Delete sub-account"
 near delete app-name.you.testnet you.testnet
 ```
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash title="Delete sub-account"
+near account delete-account app-name.you.testnet beneficiary you.testnet network-config testnet sign-with-keychain send
+```
+</TabItem>
+</Tabs>
 
 This sends all funds still on the `app-name.you.testnet` account to `you.testnet` and deletes the contract that had been deployed to it, including all contract state.
 

--- a/docs/sdk/rust/promises/token-tx.md
+++ b/docs/sdk/rust/promises/token-tx.md
@@ -47,7 +47,29 @@ Most of this is boilerplate you're probably familiar with by now – imports, s
 
 * Returning `Promise`: This allows NEAR Explorer, near-cli, near-api-js, and other tooling to correctly determine if a whole chain of transactions is successful. If your function does not return `Promise`, tools like near-cli will return immediately after your function call. And then even if the `transfer` fails, your function call will be considered successful. You can see an example of this behavior [here](https://github.com/near-examples/xcc-advanced).
 
-Using near-cli, someone could invoke this function with a call like:
+Using near-cli or near-cli-rs, someone could invoke this function with a call like:
 
-    near call $CONTRACT pay '{"amount": "1000000000000000000000000", "to": "example.near"}' --accountId benjiman.near
+<Tabs className="language-tabs" groupId="code-tabs">
+<TabItem value="Near-CLI">
+
+
+```bash
+near call <contract> pay '{"amount": "1000000000000000000000000", "to": "example.near"}' --accountId benjiman.near
+```
+
+
+
+</TabItem>
+<TabItem value="Near-CLI-rs">
+
+```bash
+near contract call-function as-transaction <contract> pay json-args '{"amount": "1000000000000000000000000", "to": "example.near"}' prepaid-gas '30 TeraGas' attached-deposit '0 NEAR' sign-as benjiman.near network-config testnet sign-with-keychain send
+```
+
+
+
+</TabItem>
+</Tabs>
+
+
 


### PR DESCRIPTION
As discussed in  https://github.com/near/docs/pull/1476.
Docs are updated with tabs for both near-cli and near-cli-rs commands .
Commands mentioned in https://github.com/near/near-cli-rs/issues/236 are yet to be changed .