### PR TITLE
Small css fix

### DIFF
--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -200,7 +200,7 @@ img+em,
 
 /* Language selection Tabs*/
 .file-tabs {
-    margin: -0.5rem 0 -2rem 0;
+    margin: 0px 0 -1rem 0rem;
     font-size: small;
 }
 


### PR DESCRIPTION
The "file tabs" on code examples are being incorrectly rendered. This small css change fixes it.