### PR TITLE
add epic template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,39 @@
+---
+name: 🔹 Create an EPIC 
+about: Create an epic of work that tracks several issues
+title: "[🔹EPIC] "
+labels: epic
+assignees: ''
+
+---
+<!-- ⚠️ Epic template, do not delete! ⚠️ -->
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+### Description
+
+(Problem statement with a description of work to be accomplished.)
+
+---
+
+### Goal
+
+(Define success. What is the desired outcome?)
+
+---
+
+### Resources
+
+(Relevant documentation, Figma links, and other reference material)
+
+- Item 1
+- Item 2
+- Item 3
+
+---
+
+```[tasklist]
+### Related Issues
+- [ ] https://github.com/near/docs/issues/1
+- [ ] https://github.com/near/docs/issues/2
+- [ ] https://github.com/near/docs/issues/3
+```


### PR DESCRIPTION
Adds an epic issue template for grouping related issues. 
- Will be used in [Docs Project](https://github.com/orgs/near/projects/117/views/1) and [NEAR DX Tracker](https://github.com/orgs/near/projects/75/views/12?sliceBy%5Bvalue%5D=near%2Fdocs). 