### PR TITLE
Add documentation for Lava ipRPC

### DIFF
--- a/docs/5.api/rpc/introduction.md
+++ b/docs/5.api/rpc/introduction.md
@@ -11,11 +11,16 @@ import ContactUs from '@site/components/ContactUs.mdx';
 The RPC API allows you to communicate directly with the NEAR network. For example,
 tools such as [near-api-js](/tools/near-api-js/quick-reference) are just abstractions making RPC calls.
 
+## Free Public RPC
+
+NEAR offers free public peer-to-peer rpc to all developers. Dozens of providers are collated under a single, unified endpoint for ease of use and immediate access. 🔥 Learn [more](iprpc#endpoints-)!
+
 <hr class="subsection" />
+
 
 ## RPC Providers
 
-There are multiple [RPC providers which you can choose from](./providers.md). These providers will work as intermediaries to help you interact with the NEAR network.
+There are multiple alternative [RPC providers which you can choose from](./providers.md). These providers will work as intermediaries to help you interact with the NEAR network.
 
 <hr class="subsection" />
 

--- a/docs/5.api/rpc/iprpc.md
+++ b/docs/5.api/rpc/iprpc.md
@@ -1,0 +1,60 @@
+---
+id: iprpc
+sidebar_label: Free Public RPC
+title: Using NEAR Incentivized Public RPC
+---
+
+
+## Overview  📋
+
+In order to provide decentralized, reliable and public RPC to all developers in the ecosystem, NEAR uses [Lava](https://www.lavanet.xyz/?utm_source=near-iprpc-dev-tutorial&utm_medium=near-docs&utm_campaign=near-iprpc-dev) to serve RPC to its developer community. Lava aggregates and routes RPC requests to a peer-to-peer network of top-performing node providers, with built-in fraud detection, conflict resolution, and quality of service guarantees for all requests. All relays are conducted securely with no man-in-the-middle. For more details on Lava's protocol, take a look at [the Lava litepaper](https://litepaper.lavanet.xyz/?utm_source=near-iprpc-dev-tutorial&utm_medium=near-docs&utm_campaign=near-iprc-dev).
+
+Lava ipRPC aggregates RPC providers and provides a unified endpoint for NEAR's entire ecosystem.
+
+
+## Endpoints 🔗
+
+A list is provided below for your convenience!
+
+### Mainnet 🌐
+
+- **JSON-RPC** - `https://near.lava.build`
+
+### Testnet 🧪
+
+- **JSON-RPC** - `https://near-testnet.lava.build`
+
+## Using `near-cli` with ipRPC ⚡
+
+You can use your `near-cli` installation with ipRPC for all calls and requests.
+
+For `mainnet` use:
+```bash
+./near <command> --nodeUrl https://near.lava.build
+```
+
+For `testnet` use:
+```bash
+./near <command> --nodeUrl https://near-testnet.lava.build
+```
+
+Using this schema, all `near-cli` commands which communicate with the blockchain will be carried out securely and efficiently over Lava ipRPC.
+
+
+## Test Commands 🖥️
+
+You can send requests to each endpoint.  This can be done with the use of different tools such as `curl` for HTTP-responsive protocols. You can also use any of the endpoints programmatically. Some examples are below:
+
+
+### 🟢 JSON-RPC
+Use CURL command to the appropriate NEAR endpoints!
+
+```bash
+# Mainnet
+curl -X POST -H "Content-Type: application/json" https://near.lava.build --data '{"jsonrpc":"2.0","method":"block","params":{"finality":"final"},"id":1}'
+
+# Testnet
+curl -X POST -H "Content-Type: application/json" https://near-testnet.lava.build --data '{"jsonrpc":"2.0","method":"block","params":{"finality":"final"},"id":1}'
+```
+
+✅ The rest is up to you! The possibilities are literally endless!

--- a/docs/5.api/rpc/providers.md
+++ b/docs/5.api/rpc/providers.md
@@ -16,6 +16,7 @@ If you want to use a custom RPC provider with NEAR Wallet Selector, [check this 
 
 | Provider   | Endpoint Root                           |
 | ---------- | --------------------------------------- |
+| [Lava Network](https://lavanet.xyz/getting-started/near)           | `https://near.lava.build`                                      |
 | [NEAR](setup.md)      | `https://rpc.mainnet.near.org`                                                |
 | [Pagoda](https://www.pagoda.co/console)    | `https://near-mainnet.api.pagoda.co/rpc/v1`                                        |
 | [1RPC](https://docs.ata.network/1rpc/introduction/) | `https://1rpc.io/near`  |

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -856,6 +856,7 @@
   ],
   "api": [
     "api/rpc/introduction",
+    "api/rpc/iprpc",
     "api/rpc/providers",
     {
       "type": "html",


### PR DESCRIPTION
This PR adds additional documentation to the RPC section of NEAR docs concerning NEAR's newly supported free public RPC using the Lava network. It includes a page detailing RPC, appends Lava's endpoint to the list of providers, and makes mention in the introductory page. In totality, changes are confined to the RPC section of NEAR's docs.

