### PR TITLE
fix: resolve fetching remote content via plugin

### DIFF
--- a/website/blog/2023-01-31-changelog.md
+++ b/website/blog/2023-01-31-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |
@@ -15,6 +17,37 @@ Developer changelog for [essential repositories](/develop/github-overview) when 
 
 ## Merged Pull Requests  🚀
 
+## 🚀 BOS
+
+### viewer
+
+| DATE | PR | DESCRIPTION |
+| --- | --- | --- |
+| 2023-01-30 | [123](https://github.com/NearSocial/viewer/pull/123) | [Expose context.widgetSrc](https://github.com/NearSocial/viewer/pull/123) |
+| 2023-01-30 | [122](https://github.com/NearSocial/viewer/pull/122) | [Refresh in-memory cache every 5 minutes](https://github.com/NearSocial/viewer/pull/122) |
+| 2023-01-26 | [121](https://github.com/NearSocial/viewer/pull/121) | [Revert "Prevent func...](https://github.com/NearSocial/viewer/pull/121) |
+| 2023-01-25 | [120](https://github.com/NearSocial/viewer/pull/120) | [Prevent functions fr...](https://github.com/NearSocial/viewer/pull/120) |
+| 2023-01-25 | [111](https://github.com/NearSocial/viewer/pull/111) | [Fix Mentions Regex](https://github.com/NearSocial/viewer/pull/111) |
+| 2023-01-25 | [118](https://github.com/NearSocial/viewer/pull/118) | [Introduce useCache](https://github.com/NearSocial/viewer/pull/118) |
+| 2023-01-24 | [117](https://github.com/NearSocial/viewer/pull/117) | [Fix constructors for non keyword methods](https://github.com/NearSocial/viewer/pull/117) |
+| 2023-01-23 | [105](https://github.com/NearSocial/viewer/pull/105) | [Allow use toLocaleString()](https://github.com/NearSocial/viewer/pull/105) |
+| 2023-01-22 | [107](https://github.com/NearSocial/viewer/pull/107) | [Fix RestElement to not delete entries](https://github.com/NearSocial/viewer/pull/107) |
+| 2023-01-20 | [106](https://github.com/NearSocial/viewer/pull/106) | [Add onMention to Mar...](https://github.com/NearSocial/viewer/pull/106) |
+| 2023-01-19 | [104](https://github.com/NearSocial/viewer/pull/104) | [Markdown to open lin...](https://github.com/NearSocial/viewer/pull/104) |
+| 2023-01-14 | [103](https://github.com/NearSocial/viewer/pull/103) | [Fix profile link](https://github.com/NearSocial/viewer/pull/103) |
+| 2023-01-13 | [102](https://github.com/NearSocial/viewer/pull/102) | [fix: Fix desktop dro...](https://github.com/NearSocial/viewer/pull/102) |
+| 2023-01-12 | [82](https://github.com/NearSocial/viewer/pull/82) | [feat: Add new navigation](https://github.com/NearSocial/viewer/pull/82) |
+| 2023-01-11 | [99](https://github.com/NearSocial/viewer/pull/99) | [Add URL, FileReader....](https://github.com/NearSocial/viewer/pull/99) |
+| 2023-01-10 | [97](https://github.com/NearSocial/viewer/pull/97) | [Expose Files compone...](https://github.com/NearSocial/viewer/pull/97) |
+| 2023-01-09 | [95](https://github.com/NearSocial/viewer/pull/95) | [Filter out non-valid...](https://github.com/NearSocial/viewer/pull/95) |
+| 2023-01-09 | [94](https://github.com/NearSocial/viewer/pull/94) | [Show an error when t...](https://github.com/NearSocial/viewer/pull/94) |
+| 2023-01-07 | [93](https://github.com/NearSocial/viewer/pull/93) | [Fix commitData witho...](https://github.com/NearSocial/viewer/pull/93) |
+| 2023-01-06 | [92](https://github.com/NearSocial/viewer/pull/92) | [Add ForOfStatement](https://github.com/NearSocial/viewer/pull/92) |
+| 2023-01-06 | [91](https://github.com/NearSocial/viewer/pull/91) | [Add SwitchStatement](https://github.com/NearSocial/viewer/pull/91) |
+| 2023-01-06 | [90](https://github.com/NearSocial/viewer/pull/90) | [Add Map and Set objects](https://github.com/NearSocial/viewer/pull/90) |
+| 2023-01-06 | [88](https://github.com/NearSocial/viewer/pull/88) | [Expose most SVG tags](https://github.com/NearSocial/viewer/pull/88) |
+| 2023-01-05 | [86](https://github.com/NearSocial/viewer/pull/86) | [Update wallet select...](https://github.com/NearSocial/viewer/pull/86) |
+
 ## 🔑 Wallet / Auth
 
 ### wallet-selector
@@ -24,6 +57,40 @@ Developer changelog for [essential repositories](/develop/github-overview) when 
 | 2023-01-27 | [667](https://github.com/near/wallet-selector/pull/667) | [v7.6.1 Release (dev -> main)](https://github.com/near/wallet-selector/pull/667) |
 | 2023-01-24 | [660](https://github.com/near/wallet-selector/pull/660) | [v7.6.0 Release (dev -> main)](https://github.com/near/wallet-selector/pull/660) |
 | 2023-01-13 | [645](https://github.com/near/wallet-selector/pull/645) | [v7.5.0 Release (dev -> main)](https://github.com/near/wallet-selector/pull/645) |
+
+## 🖥️ CLI
+
+### near-cli
+
+| DATE | PR | DESCRIPTION |
+| --- | --- | --- |
+| 2023-01-11 | [1046](https://github.com/near/near-cli/pull/1046) | [feat: Allow --force argument on deletion](https://github.com/near/near-cli/pull/1046) |
+
+## 📝 Smart Contracts
+
+### near-sdk-rs
+
+| DATE | PR | DESCRIPTION |
+| --- | --- | --- |
+| 2023-01-23 | [998](https://github.com/near/near-sdk-rs/pull/998) | [Update visibility of FreeList and method](https://github.com/near/near-sdk-rs/pull/998) |
+| 2023-01-23 | [982](https://github.com/near/near-sdk-rs/pull/982) | [fix: strip return types of lifetimes](https://github.com/near/near-sdk-rs/pull/982) |
+| 2023-01-23 | [980](https://github.com/near/near-sdk-rs/pull/980) | [fix: prohibit NEAR function generics](https://github.com/near/near-sdk-rs/pull/980) |
+| 2023-01-23 | [1001](https://github.com/near/near-sdk-rs/pull/1001) | [fix: concretize `Sel...](https://github.com/near/near-sdk-rs/pull/1001) |
+| 2023-01-23 | [1004](https://github.com/near/near-sdk-rs/pull/1004) | [chore: add miraclx to codeowners](https://github.com/near/near-sdk-rs/pull/1004) |
+| 2023-01-23 | [1003](https://github.com/near/near-sdk-rs/pull/1003) | [fix: fully qualify t...](https://github.com/near/near-sdk-rs/pull/1003) |
+| 2023-01-23 | [971](https://github.com/near/near-sdk-rs/pull/971) | [fix: `__abi-embed` compilation error](https://github.com/near/near-sdk-rs/pull/971) |
+| 2023-01-04 | [999](https://github.com/near/near-sdk-rs/pull/999) | [chore: remove Austin from codeowners](https://github.com/near/near-sdk-rs/pull/999) |
+
+### keypom
+
+| DATE | PR | DESCRIPTION |
+| --- | --- | --- |
+| 2023-01-24 | [89](https://github.com/keypom/keypom/pull/89) | [Fixed FT tests](https://github.com/keypom/keypom/pull/89) |
+| 2023-01-24 | [88](https://github.com/keypom/keypom/pull/88) | [add funder_id and fi...](https://github.com/keypom/keypom/pull/88) |
+| 2023-01-24 | [87](https://github.com/keypom/keypom/pull/87) | [refactored and new sdk deploy scripts](https://github.com/keypom/keypom/pull/87) |
+| 2023-01-24 | [78](https://github.com/keypom/keypom/pull/78) | [Test comments](https://github.com/keypom/keypom/pull/78) |
+| 2023-01-24 | [79](https://github.com/keypom/keypom/pull/79) | [Unnecessary Computation in Add Keys](https://github.com/keypom/keypom/pull/79) |
+| 2023-01-03 | [86](https://github.com/keypom/keypom/pull/86) | [Panics From Rust SDK Data Types](https://github.com/keypom/keypom/pull/86) |
 
 ## 🧪 Testing
 
@@ -38,3 +105,24 @@ Developer changelog for [essential repositories](/develop/github-overview) when 
 | 2023-01-10 | [258](https://github.com/near/near-workspaces-rs/pull/258) | [fix: storing credentials](https://github.com/near/near-workspaces-rs/pull/258) |
 | 2023-01-10 | [241](https://github.com/near/near-workspaces-rs/pull/241) | [fix: ulimit error](https://github.com/near/near-workspaces-rs/pull/241) |
 | 2023-01-09 | [249](https://github.com/near/near-workspaces-rs/pull/249) | [Removed the lifetime in transact_async](https://github.com/near/near-workspaces-rs/pull/249) |
+
+## 🔎 Data Indexing
+
+### near-lake-framework-rs
+
+| DATE | PR | DESCRIPTION |
+| --- | --- | --- |
+| 2023-01-26 | [56](https://github.com/near/near-lake-framework-rs/pull/56) | [chore: Update NEAR L...](https://github.com/near/near-lake-framework-rs/pull/56) |
+| 2023-01-26 | [55](https://github.com/near/near-lake-framework-rs/pull/55) | [refactor: Internal r...](https://github.com/near/near-lake-framework-rs/pull/55) |
+
+## ⛓️ Protocol
+
+### neps
+
+| DATE | PR | DESCRIPTION |
+| --- | --- | --- |
+| 2023-01-27 | [418](https://github.com/near/NEPs/pull/418) | [Proposal to allow at...](https://github.com/near/NEPs/pull/418) |
+| 2023-01-24 | [351](https://github.com/near/NEPs/pull/351) | [feat: add `standards...](https://github.com/near/NEPs/pull/351) |
+| 2023-01-11 | [445](https://github.com/near/NEPs/pull/445) | [Update SelecitonBloc...](https://github.com/near/NEPs/pull/445) |
+| 2023-01-11 | [447](https://github.com/near/NEPs/pull/447) | [doc: Fix gas price c...](https://github.com/near/NEPs/pull/447) |
+| 2023-01-09 | [444](https://github.com/near/NEPs/pull/444) | [Remove specs/Economics/README.md](https://github.com/near/NEPs/pull/444) |

--- a/website/blog/2023-02-28-changelog.md
+++ b/website/blog/2023-02-28-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-03-31-changelog.md
+++ b/website/blog/2023-03-31-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-04-30-changelog.md
+++ b/website/blog/2023-04-30-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-05-31-changelog.md
+++ b/website/blog/2023-05-31-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-06-30-changelog.md
+++ b/website/blog/2023-06-30-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-07-31-changelog.md
+++ b/website/blog/2023-07-31-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-08-31-changelog.md
+++ b/website/blog/2023-08-31-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-09-30-changelog.md
+++ b/website/blog/2023-09-30-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-10-31-changelog.md
+++ b/website/blog/2023-10-31-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |

--- a/website/blog/2023-11-30-changelog.md
+++ b/website/blog/2023-11-30-changelog.md
@@ -2,6 +2,8 @@
 
 Developer changelog for [essential repositories](/develop/github-overview) when building on NEAR Protocol. 🏗️
 
+👉 [Get monthly emails of this report](https://docs.google.com/forms/d/1JfFUbTq3ELUlScJT1UI9PQPuQsv0W2jcTa7P94KrS5U/edit) 👈
+
 ## Releases  🎉
 
 | repo | release | release_date |
@@ -353,10 +355,6 @@ Developer changelog for [essential repositories](/develop/github-overview) when 
 | 2023-11-20 | [10180](https://github.com/near/nearcore/pull/10180) | [introduce code coverage analysis in CI](https://github.com/near/nearcore/pull/10180) |
 | 2023-11-20 | [10205](https://github.com/near/nearcore/pull/10205) | [enable debug assertions in CI](https://github.com/near/nearcore/pull/10205) |
 | 2023-11-20 | [10214](https://github.com/near/nearcore/pull/10214) | [Bump various dependency versions](https://github.com/near/nearcore/pull/10214) |
-| 2023-11-20 | [10217](https://github.com/near/nearcore/pull/10217) | [fix broken links, an...](https://github.com/near/nearcore/pull/10217) |
-| 2023-11-20 | [10187](https://github.com/near/nearcore/pull/10187) | [refactor: prepare sh...](https://github.com/near/nearcore/pull/10187) |
-| 2023-11-20 | [10191](https://github.com/near/nearcore/pull/10191) | [[Snyk] Upgrade react...](https://github.com/near/nearcore/pull/10191) |
-| 2023-11-20 | [10212](https://github.com/near/nearcore/pull/10212) | [build(deps-dev): bum...](https://github.com/near/nearcore/pull/10212) |
 
 ### neps
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -70,7 +70,7 @@ module.exports = {
       'docusaurus-plugin-remote-content',
       {
         // options here
-        name: 'dx-content', // used by CLI, must be path safe
+        name: 'dx', // used by CLI, must be path safe
         sourceBaseUrl: 'https://raw.githubusercontent.com/near/DX/main/',
         outDir: '../docs/2.develop',
         documents: ['README.md'],
@@ -97,7 +97,7 @@ ${content}`, // <-- this last part adds in the rest of the content, which would 
     [
       'docusaurus-plugin-remote-content',
       {
-        name: 'near-changelog',
+        name: 'changelog',
         sourceBaseUrl:
           'https://raw.githubusercontent.com/near/near-releases/main/reports/',
         outDir: '/blog',

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "preview": "(eval $(echo check_$IS_PULL_REQUEST | grep -U 'check_false')) 2>/dev/null && docusaurus build --locale en",
     "swizzle": "docusaurus swizzle",
     "docusaurus": "docusaurus",
-    "check-logs": "node ./src/utils/getChangelogs.js",
+    "remote-sync": "node ./src/utils/getChangelogs.js && npm run docusaurus download-remote-changelog && npm run docusaurus download-remote-dx",
     "crowdin": "crowdin",
     "crowdin:sync": "docusaurus write-translations && crowdin upload && crowdin download",
     "crowdin:build": "(eval $(echo check_$IS_PULL_REQUEST | grep -U 'check_true')) 2>/dev/null && docusaurus write-translations && crowdin download"


### PR DESCRIPTION
**Issue:**

[This commit disables remote syncing](https://github.com/near/docs/commit/cb7e34abead2ad59f551fbfc086323bfd1a78fe0#diff-bc4913d026ae51bef2bc8b7a1c040fdf52b999d99e6fa40d87b379f98a60e0eaR105)  and requires a CLI command to check for updates. 
_(Changing `noRuntimeDownloads` to `true`)_

@gagdiez I believe you created the `check-logs` script to implement the CLI check but unfortunately it does not work as expected.  Running `getChangelogs.js` only updates an array of strings (markdown file names) that tells the `remote-content` plugin which files to look for. The CLI command requires running: [`docusaurus download-remote`](https://github.com/rdilweb/docusaurus-plugin-remote-content?tab=readme-ov-file#cli-sync) for each section

**This PR:**

- fixes `check-logs` script in `package.json` (now called `remote-sync`)
- updates reports w/ updated content (email subscription)


**TODO:** 

- Create a CI pipeline that runs `remote-sync` on a regular cadence 
- Consider importing `near-releases` as a submodule for this repo