### PR TITLE
Improve styles for Wallet Selector modal

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -388,4 +388,18 @@ iframe+em {
 
 /* BOOTSTRAP */
 /* TODO: Include this from file */
-@import './bootstrap.scss'
+@import './bootstrap.scss';
+
+#near-wallet-selector-modal {
+  .nws-modal-wrapper .nws-modal .modal-left .modal-left-title h2 {
+    font-family: inherit;
+  }
+  .nws-modal-wrapper .nws-modal .modal-right .nws-modal-header h3.middleTitle {
+    margin: 4px auto !important;
+    font-family: inherit;
+  }
+
+  .nws-modal-wrapper .nws-modal .modal-right .wallet-what .content-side h3 {
+    margin: 0 auto 8px 0 !important;
+  }
+}


### PR DESCRIPTION
# Description

This PR improves the alignment of the dom elements in the wallet-selector modal-ui since the styles are being overridden by the global styles.

### Before

![image](https://github.com/near/docs/assets/95851345/2070a80a-ace9-48dd-9c70-4249da726fcb)


### After

![image](https://github.com/near/docs/assets/95851345/0ce91f71-78f6-46a5-9f2f-1ebb00f9c63a)
