### PR TITLE
Provide the list of wallets that support signMessage

### DIFF
--- a/docs/2.develop/integrate/backend.md
+++ b/docs/2.develop/integrate/backend.md
@@ -35,7 +35,16 @@ Here we use [crypto.randomBytes](https://nodejs.org/api/crypto.html#crypto_crypt
 :::
 
 ### 2. Ask the User to Sign the Challenge
-As of today only [Meteor Wallet](https://meteorwallet.app) supports the `signMessage` method needed to sign the challenge. However, we expect more wallets to support this method in the future.
+The `signMessage` method needed to sign the challenge is supported by these wallets:
+- Meteor Wallet
+- Here Wallet
+- Near Snap
+- Nightly Wallet
+- WELLDONE Wallet
+- NearMobileWallet
+- MyNearWallet
+- Sender
+
 
 The message that the user needs to sign contains 4 fields:
 - Message: The message that the user is signing.


### PR DESCRIPTION
The paragraph here is confusing because it contains outdated information:
>As of today only [Meteor Wallet](https://meteorwallet.app) supports the `signMessage` method needed to sign the challenge. However, we expect more wallets to support this method in the future.

![Screenshot 2024-02-08 233844](https://github.com/near/docs/assets/95851345/81b65311-5a87-453e-9a3c-d00e91ea8364)


---

This PR provides the list of wallets that currently support `signMessage`.

Open to other suggestions 👍 
