### PR TITLE
Elevate chain abstraction docs in `build` section

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -129,6 +129,28 @@ const sidebar = {
     },
     {
       "type": "html",
+      "value": "<span class='menu__link'><b><small> Chain Abstraction ✨ </small></b></span>"
+    },
+    'abstraction/what-is',
+    {
+      "Chain Abstraction Services": [
+        "develop/relayers/build-relayer",
+        'tools/fastauth-sdk',
+        'abstraction/chain-signatures',
+        {
+          "Multichain Gas Relayer": [
+            "develop/relayers/multichain-server",
+            "develop/relayers/gas-station",
+          ]
+        },
+      ]
+    },
+    {
+      "type": "html",
+      "value": "<hr/>"
+    },
+    {
+      "type": "html",
       "value": "<span class='menu__link'><b><small> Smart Contracts </small></b></span>"
     },
     "develop/contracts/whatisacontract",
@@ -265,28 +287,6 @@ const sidebar = {
           "value": "<a class='menu__link internal' href='/tutorials/examples/count-near'> 📖 Tutorials </a>",
         },
       ],
-    },
-    {
-      "type": "html",
-      "value": "<hr/>"
-    },
-    {
-      "type": "html",
-      "value": "<span class='menu__link'><b><small> Chain Abstraction ✨ </small></b></span>"
-    },
-    'abstraction/what-is',
-    {
-      "Chain Abstraction Services": [
-        "develop/relayers/build-relayer",
-        'tools/fastauth-sdk',
-        'abstraction/chain-signatures',
-        {
-          "Multichain Gas Relayer": [
-            "develop/relayers/multichain-server",
-            "develop/relayers/gas-station",
-          ]
-        },
-      ]
     },
     {
       "type": "html",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -64,7 +64,7 @@ const sidebar = {
     },
     {
       "type": "html",
-      "value": "<span class='menu__link'><b><small> Chain Abstraction </small></b></span>"
+      "value": "<span class='menu__link'><b><small> Chain Abstraction ✨</small></b></span>"
     },
     "concepts/abstraction/introduction",
     "concepts/abstraction/relayers",


### PR DESCRIPTION
Currently, Chain Abstraction docs are several sections down on the left nav under `Build`. This PR elevates them to the top for higher discoverability.

**BEFORE:**
![Screenshot 2024-02-26 at 4 19 06 PM](https://github.com/near/docs/assets/58483342/216569c5-d881-436b-b166-d953d711fc3c)

**AFTER:**
![Screenshot 2024-02-26 at 4 19 22 PM](https://github.com/near/docs/assets/58483342/331a97be-096e-4ce8-9a45-b5788937be04)
