### PR TITLE
Updated nft marketplace logic

### DIFF
--- a/docs/3.tutorials/nfts/5-approval.md
+++ b/docs/3.tutorials/nfts/5-approval.md
@@ -137,21 +137,9 @@ After the assertion comes back with no problems, you get the token object and ma
 
 You then calculate how much storage is being used by adding that new account to the map and increment the tokens `next_approval_id` by 1. After inserting the token object back into the `tokens_by_id` map, you refund any excess storage.
 
-You'll notice that the function contains an optional `msg` parameter. This message is actually the foundation of all NFT marketplaces on NEAR.
+You'll notice that the function contains an optional `msg` parameter. This message can be used by NFT marketplaces. If a message was provided into the function, you're going to perform a cross contract call to the account being given access. This cross contract call will invoke the `nft_on_approve` function which will parse the message and act accordingly.
 
-#### Marketplace Integrations {#marketplace-integrations}
-
-If a message was provided into the function, you're going to perform a cross contract call to the account being given access. This cross contract call will invoke the `nft_on_approve` function which will parse the message and act accordingly. Let's consider a general use case.
-
-We have a marketplace that expects it's sale conditions to be passed in through the message field. Benji approves the marketplace with the `nft_approve` function and passes in a stringified JSON to the message which will outline sale conditions. These sale conditions could look something like the following:
-
-```json
-sale_conditions: {
-    price: 5
-}
-```
-
-By leaving the message field type as just a string, this generalizes the process and allows users to input sale conditions for many different marketplaces. It is up to the person approving to pass in an appropriate message that the marketplace can properly decode and use. This is usually done through the marketplace's frontend app which would know how to construct the `msg` in a useful way.
+It is up to the person approving to pass in an appropriate message that the marketplace can properly decode and use. This is usually done through the marketplace's frontend app which would know how to construct the `msg` in a useful way.
 
 #### Internal functions
 


### PR DESCRIPTION
We leave nft_on_approve callback for some internal marketplace logic and create a new list_nft_for_sale method. In this method, we check if the signer is NFT owner and if the marketplace contract is approved on NFT.