### PR TITLE
re-organize chain abstraction

### DIFF
--- a/docs/1.concepts/abstraction/chain-signatures.md
+++ b/docs/1.concepts/abstraction/chain-signatures.md
@@ -4,54 +4,57 @@ title: Chain Signatures
 sidebar_label: What are Chain Signatures?
 ---
 
-Chain Signatures unlock the ability for a single account to transact across multiple blockchain protocols, giving ownership of cross-chain accounts, data, and assets to one NEAR account.
+Chain Signatures allow NEAR accounts to request signatures for transactions on other blockchains.
 
-This many-to-one ownership is made possible through a mixture of services across our tech stack:
+Thanks to chain signatures, a NEAR account can safely control multiple accounts across different blockchains, enabling true ownership of cross-chain data and assets.
 
-1. A [smart contract](../basics/accounts/smartcontract.md) that holds requests for multi-chain signatures.
-2. A [multiparty computation](https://www.zellic.io/blog/mpc-from-scratch/) service listening for signature requests.
-3. A multi-chain [relayer](./relayers.md), which can submit signed transactions to other networks.
-
-:::info
-This section presents an overview of Chain Signatures. To create one, please switch to the [**building a Chain Signature**](../../8.abstraction/chain-signatures.md) document.
+:::info Searching for code?
+This document presents only broad concepts, to include Chain Signatures in your project check the [**build documentation**](../../8.abstraction/chain-signatures.md)
 :::
 
 ---
 
 ## How It Works
 
-![chain-signatures](/docs/assets/welcome-pages/chain-signatures-overview.png)
-_Diagram of a chain signature in NEAR_
+Controlling accounts on other chains is made possible thanks to the interaction between three elements:
 
-There are four steps involved on Chain Signatures:
-
-1. [Create a Payload](#1-create-a-payload) - The user creates the transaction / message they want to sign
-2. [Signature Request](#2-request-signature) - The user calls the NEAR `multichain` contract, requesting to sign the transaction
-3. [MPC Signing Service](#3-sign-with-mpc) - A service captures the call, and returns the signed the transaction for the user
-4. [Relay Signed Payload](#4-relaying-the-signature) - The signed payload is then sent to the destination chain for execution.
+1. A deterministic way to derive [**multiple foreign addresses**](#one-account-multiple-chains) from one NEAR account
+2. A **smart contract** that receives requests to sign transaction for other chains
+3. A [**multiparty computation**](#3-mpc-signing-service) service that provides the smart contract with the signatures
 
 <hr class="subsection" />
 
-### 1. Create Payload
+### Derivation Paths: One Account, Multiple Chains
+Chain Signatures link NEAR accounts to other blockchain accounts using what we call `derivation paths` (or `paths` for short). 
 
-The first step is to construct a payload (transaction, message, data, etc.) for the target blockchain platform. This variates depending on the target blockchain, but in general, it's a hash of the message or transaction to be signed.
+A path is just a string (e.g. `ethereum-1`, `ethereum-2`, etc) that, in conjunction with the NEAR account, denotes a unique address on the target blockchain.
+
+For example, we can derive multiple Ethereum accounts from `influencer.testnet` by using different paths:
+
+  1. `influencer.testnet` + `ethereum-1` = `0x1b48b83a308ea4beb845db088180dc3389f8aa3b`
+  2. `influencer.testnet` + `ethereum-2` = `0x99c5d3025dc736541f2d97c3ef3c90de4d221315`
+  3. `influencer.testnet` + `...` = `0x...` 
+
+:::info Technical Details
+The external address is deterministically derived from the account's ID, the path, and the MPC service's public key.
+
+See our Build section to see [how the derivation is implemented](../../8.abstraction/chain-signatures.md#1-deriving-the-foreign-address).
+:::
 
 <hr class="subsection" />
 
-### 2. Signature Request
+### A Contract for Chain Signatures
+A deployed smart contract is used to request signatures for transactions on other blockchains.
 
-Once a payload is created and ready to sign, a signature request is made by calling `sign` on the deployed smart contract `multichain.near`. This method takes two parameters:
-  1. **payload:** The payload (transaction, message, data, etc.) to be signed for the target blockchain
-  2. **path:** A name representing the account that should be used to sign the payload (e.g. ethereum-1)
-
-```rust
-  pub fn sign(payload: [u8; 32], path: String) -> Signature
-```
-_[See the full code in Github](https://github.com/near/mpc-recovery/blob/bc85d66833ffa8537ec61d0b22cd5aa96fbe3197/contract/src/lib.rs#L263)_
+The contract has a method called `sign` that takes two parameters:
+  1. The `payload` (transaction) to be signed for the target blockchain
+  2. The `path` that identifies the account we want to use to sign the payload.
 
 For example, a user could request a signature to `send 0.1 ETH to 0x060f1...` **(payload)** using the `ethereum-1` account **(path)**.
 
-After a request is made, the `sign` method starts recursively calling itself in order to wait while the [MPC signing service](#3-mpc-signing-service) signs the payload.
+After a request is made, the `sign` method starts recursively calling itself in order to wait while the [MPC signing service](#multi-party-computation-service-mpc) signs the payload. 
+
+Once the signature is ready, the contract will gain access to it, and return it to the user. This signature is a valid signed transaction that can be readily sent to the target blockchain to be executed.
 
 <details>
 <summary> A Contract Recursively Calling Itself? </summary>
@@ -62,49 +65,38 @@ Note that each call will take one block, and thus result on ~1s of waiting. Afte
 
 </details>
 
-<hr class="subsection" />
-
-### 3. MPC Signing Service
-
-A multi-party computation service (`MPC service`, see more below) is constantly listening for signature requests (i.e. users calling the `sign` method). When a call is detected, the service will:
-
-1. Use the `accountId` of the requester, and the `path` (in our example, `ethereum-1`) to derive a key 
-2. Sign the `payload` (in our example, a transaction transferring ETH) using the stored key
-3. Call the contract `multichain.near`, storing the resulting `Signature`
-
-:::tip
-Every time an account makes a signature request using the same `path`, the same `key` will be derived. This allows to use always the same account to sign different transactions.
+:::info Technical Details
+Curious on how you can use the contract? Check the technical docs: [requesting the signature](../../8.abstraction/chain-signatures.md#3-requesting-the-signature).
 :::
-
-<details>
-<summary> What is an MPC Service? </summary>
-
-MPC (multi-party computation) allows independent actors to do shared computations on private information, without revealing secrets to each-other.
-
-NEAR uses its own MPC service to safely sign transactions for other chains on behalf of the user. In practice, **no single node** on the MPC can **sign by itself** since they do **not hold the user's keys**. Instead, nodes create signature-shares which are aggregated through multiple rounds to jointly sign the payload.
-
-Generally, MPC signing services work by sharing a master key, which needs to be re-created each time a node joins or leaves. NEAR's MPC service allows for nodes to safely join and leave, without needing to re-derive a master key.
-
-If you want to learn more about how MPC works, we recommend to [**check this article**](https://www.zellic.io/blog/mpc-from-scratch/)
-
-</details>
 
 <hr class="subsection" />
 
-### 4. Relaying the Signature
+### Multi-Party Computation Service (MPC)
+Multi-party computation (MPC) allows independent actors to do shared computations on private information, without revealing secrets to each-other.
 
-At this point - assuming the contract didn't run out of gas waiting - the contract will return the response for the signature request. This response is a valid signed transaction that can be readily sent to the target blockchain to be executed.
+The NEAR MPC service is constantly listening for signature requests (i.e. users calling the `sign` method). When a call is detected, the MPC service will:
+  1. Ask its nodes to jointly derive a signature for the `payload` using the account identified by the `path`
+  2. Call the multichain contract, storing the resulting `Signature`
 
-To simplify relaying the transaction, we are building an indexer that will automatically capture the signature, and submit it to the target chain using a multi-chain [relayer](relayers.md).
+It is important to notice that the signature process is not performed by a single node, but by multiple nodes working together to sign the payload.
 
-:::tip
-A multi-chain [relayer](relayers.md) is a service that knows how to relay signed transactions into their target networks so they are executed on-chain.
+**No single node can sign by itself** since they do **not hold the user's keys**. Instead, nodes create **signature-shares** which are **aggregated through multiple rounds** to **jointly** sign the payload.
+
+:::info A Custom MPC Service
+Generally, MPC signing services work by sharing a master key, which needs to be re-created each time a node joins or leaves
+
+NEAR's MPC service allows for nodes to safely join and leave, without needing to re-derive a master key
 :::
 
-<!-- ### Workflow
+:::tip
+Want to learn more about the mathematics that enable MPC? [**Check this awesome article**](https://www.zellic.io/blog/mpc-from-scratch/)
+:::
 
-- A NEAR account requests a payload to be signed by a deployed [MPC](#multi-party-computation-mpc) smart contract
-  > This request is performed by calling `sign` and passing the payload (hash from a message or transaction)
-- A key is derived from the MPC root key using `account_id` and derivation path. (this ensures that it will be the same key if the two parameters are the same)
-- Once the client gets the signature, it can send the transaction to a relayer
-  > In a future release, an indexing service will listen to all `sign` events from the MPC contract and will trigger a multi-chain relayer -->
+---
+
+## Concluding Remarks
+Chain Signatures are a powerful tool that allows NEAR accounts to control accounts on other blockchains. This is a fundamental step towards enabling true ownership of cross-chain data and assets.
+
+For the user, the process is made completely **on chain**, since they only need to make a call to a smart contract and wait for the response.
+
+Thanks to `derivation paths`, a single NEAR account can control **multiple accounts** on different blockchains, and thanks to the MPC service, the user can be sure that **nobody but themselves** can request signatures for those accounts.

--- a/docs/1.concepts/abstraction/chain-signatures.md
+++ b/docs/1.concepts/abstraction/chain-signatures.md
@@ -9,7 +9,9 @@ Chain Signatures allow NEAR accounts to request signatures for transactions on o
 Thanks to chain signatures, a NEAR account can safely control multiple accounts across different blockchains, enabling true ownership of cross-chain data and assets.
 
 :::info Searching for code?
-This document presents only broad concepts, to include Chain Signatures in your project check the [**build documentation**](../../8.abstraction/chain-signatures.md)
+
+This document presents only broad concepts, to include Chain Signatures in your project, check the [**build documentation**](../../8.abstraction/chain-signatures.md)
+
 :::
 
 ---
@@ -20,7 +22,7 @@ Controlling accounts on other chains is made possible thanks to the interaction 
 
 1. A deterministic way to derive [**multiple foreign addresses**](#one-account-multiple-chains) from one NEAR account
 2. A **smart contract** that receives requests to sign transaction for other chains
-3. A [**multiparty computation**](#3-mpc-signing-service) service that provides the smart contract with the signatures
+3. A [**multiparty computation service**](#multi-party-computation-service-mpc) that provides the signatures to the smart contract
 
 <hr class="subsection" />
 
@@ -46,9 +48,9 @@ See our Build section to see [how the derivation is implemented](../../8.abstrac
 ### A Contract for Chain Signatures
 A deployed smart contract is used to request signatures for transactions on other blockchains.
 
-The contract has a method called `sign` that takes two parameters:
+The contract has a `sign` method that takes two parameters:
   1. The `payload` (transaction) to be signed for the target blockchain
-  2. The `path` that identifies the account we want to use to sign the payload.
+  2. The `path` that identifies the account you want to use to sign the payload.
 
 For example, a user could request a signature to `send 0.1 ETH to 0x060f1...` **(payload)** using the `ethereum-1` account **(path)**.
 
@@ -72,7 +74,7 @@ Curious on how you can use the contract? Check the technical docs: [requesting t
 <hr class="subsection" />
 
 ### Multi-Party Computation Service (MPC)
-Multi-party computation (MPC) allows independent actors to do shared computations on private information, without revealing secrets to each-other.
+Multi-party computation (MPC) allows independent actors to do shared computations on private information without revealing secrets to each other.
 
 The NEAR MPC service is constantly listening for signature requests (i.e. users calling the `sign` method). When a call is detected, the MPC service will:
   1. Ask its nodes to jointly derive a signature for the `payload` using the account identified by the `path`

--- a/docs/8.abstraction/chain-signatures.md
+++ b/docs/8.abstraction/chain-signatures.md
@@ -12,7 +12,7 @@ NEAR accounts can safely control accounts across different blockchain protocols,
 ![chain-signatures](/docs/assets/welcome-pages/chain-signatures-overview.png)
 _Diagram of a chain signature in NEAR_
 
-There are five steps involved on Chain Signatures:
+There are five steps involved in Chain Signatures:
 
 1. [Deriving the Foreign Address](#1-deriving-foreigner-the-address) - Reconstruct the address that will be controlled on the target blockchain
 2. [Creating a Payload](#2-creating-the-payload) - Create the transaction / message that we want to sign for the target blockchain
@@ -30,7 +30,7 @@ See our [web-app example](https://github.com/near-examples/near-multichain) and 
 
 Chain Signatures use [`derivation paths`](../1.concepts/abstraction/chain-signatures.md#one-account-multiple-chains) to represent accounts on the target blockchain.
 
-The external address can be deterministically derived from the NEAR's address (e.g. `ana.near`), a derivation path (a string such as `ethereum-1`, `ethereum-2`, etc), and the MPC service's public key.
+The external address can be deterministically derived from the NEAR address (e.g., `ana.near`), a derivation path (a string such as `ethereum-1`, `ethereum-2`, etc), and the MPC service's public key.
 
 We recommend to use our example code to derive the address, as it's a complex process that involves hashing and encoding: 
 

--- a/docs/8.abstraction/chain-signatures.md
+++ b/docs/8.abstraction/chain-signatures.md
@@ -1,38 +1,53 @@
 ---
 id: chain-signatures
-title: Cross-Chain Signatures
+title: Chain Signatures
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {CodeTabs, Language, Github} from "@site/src/components/codetabs"
 
-NEAR accounts can safely control accounts across different blockchain protocols, allowing each NEAR account to have true ownership of cross-chain data and assets.
+Chain signatures enable NEAR accounts, including smart contracts, to sign and execute transactions across many blockchain protocols.
+
+This unlocks the next level of blockchain interoperability by giving ownership of diverse assets, cross-chain accounts, and data to a single NEAR account.
+
+:::info
+
+This guide will take you through a step by step process for creating a Chain Signature.
+
+⭐️ For a deep dive into the concepts of Chain Signatures see [What are Chain Signatures?](/concepts/abstraction/chain-signatures)
+
+⭐️ For complete examples of a NEAR account performing Eth transactions:
+
+- [web-app example](https://github.com/near-examples/near-multichain)
+- [component example](https://test.near.social/md1.testnet/widget/chainsig-sign-eth-tx) 
+
+:::
+
+## Create a Chain Signature
+
+There are five steps to create a Chain Signature:
+
+1. [Deriving the Foreign Address](#1-deriving-the-foreign-address) - Construct the address that will be controlled on the target blockchain
+2. [Creating a Transaction](#2-creating-the-transaction) - Create the transaction or message to be signed
+3. [Requesting a Signature](#3-requesting-the-signature) - Call the NEAR `multichain` contract and requesting to sign the transaction
+4. [Reconstructing the Signature](#4-reconstructing-the-signature) - Reconstruct the signature from the MPC service's response
+5. [Relaying the Signed Transaction](#5-relaying-the-signature) - Send the signed transaction to the destination chain for execution
 
 ![chain-signatures](/docs/assets/welcome-pages/chain-signatures-overview.png)
 _Diagram of a chain signature in NEAR_
-
-There are five steps involved in Chain Signatures:
-
-1. [Deriving the Foreign Address](#1-deriving-foreigner-the-address) - Reconstruct the address that will be controlled on the target blockchain
-2. [Creating a Payload](#2-creating-the-payload) - Create the transaction / message that we want to sign for the target blockchain
-3. [Requesting a Signature](#3-requesting-the-signature) - Call the NEAR multichain contract, requesting to sign the payload
-4. [Reconstructing the Signature](#4-reconstructing-the-signature) - Reconstruct the signature from the MPC service's response
-5. [Relaying the Signed Payload](#5-relaying-the-signature) - The signed payload is then sent to the destination chain for execution.
-
-:::info Looking for examples?
-See our [web-app example](https://github.com/near-examples/near-multichain) and [component example](https://test.near.social/md1.testnet/widget/chainsig-sign-eth-tx) showing how a NEAR account can create transactions on Ethereum.
-::: 
 
 ---
 
 ## 1. Deriving the Foreign Address
 
-Chain Signatures use [`derivation paths`](../1.concepts/abstraction/chain-signatures.md#one-account-multiple-chains) to represent accounts on the target blockchain.
+Chain Signatures use [`derivation paths`](../1.concepts/abstraction/chain-signatures.md#one-account-multiple-chains) to represent accounts on the target blockchain. The external address can be deterministically derived from:
 
-The external address can be deterministically derived from the NEAR address (e.g., `ana.near`), a derivation path (a string such as `ethereum-1`, `ethereum-2`, etc), and the MPC service's public key.
+- The NEAR address _(e.g., `example.near`, `example.testnet`, etc.)_
+- A derivation path _(a string such as `ethereum-1`, `ethereum-2`, etc.)_
+- The MPC service's public key
 
-We recommend to use our example code to derive the address, as it's a complex process that involves hashing and encoding: 
+We recommend using this example code snippet to derive the address, as it's a complex process that involves hashing and encoding:
 
 <Tabs groupId="code-tabs">
   <TabItem value="Ξ Ethereum">
@@ -52,14 +67,15 @@ We recommend to use our example code to derive the address, as it's a complex pr
 :::tip
 The same NEAR account and path will always produce the same address on the target blockchain.
 
-- `influencer.testnet` + `ethereum-1` = `0x1b48b83a308ea4beb845db088180dc3389f8aa3b`
-- `influencer.testnet` + `ethereum-2` = `0x99c5d3025dc736541f2d97c3ef3c90de4d221315`
+- `example.near` + `ethereum-1` = `0x1b48b83a308ea4beb845db088180dc3389f8aa3b`
+- `example.near` + `ethereum-2` = `0x99c5d3025dc736541f2d97c3ef3c90de4d221315`
 :::
 
 ---
 
-## 2. Creating the Payload
-Constructing the payload to be signed (transaction, message, data, etc.) variates depending on the target blockchain, but in general, it's just the hash of the message or transaction to be signed.
+## 2. Creating the Transaction
+
+Constructing the transaction to be signed (transaction, message, data, etc.) varies depending on the target blockchain, but generally it's the hash of the message or transaction to be signed.
 
 <Tabs groupId="code-tabs">
   <TabItem value="Ξ Ethereum">
@@ -76,12 +92,14 @@ Constructing the payload to be signed (transaction, message, data, etc.) variate
 
 ---
 
-## 3. Requesting the Signature 
-Once the payload is created and ready to be signed, a signature request is made by calling `sign` on the [MPC smart contract](https://github.com/near/mpc-recovery/blob/develop/contract/src/lib.rs#L298). 
+## 3. Requesting the Signature
 
-The method expects two parameters: 
-  1. The `payload` to be signed for the target blockchain
-  2. The derivation `path` for the account we want to use to sign the payload.
+Once the transaction is created and ready to be signed, a signature request is made by calling `sign` on the [MPC smart contract](https://github.com/near/mpc-recovery/blob/develop/contract/src/lib.rs#L298).
+
+The method requires two parameters:
+
+  1. The `transaction` to be signed for the target blockchain
+  2. The derivation `path` for the account we want to use to sign the transaction
 
 <Tabs groupId="code-tabs">
   <TabItem value="Ξ Ethereum">
@@ -99,36 +117,22 @@ The method expects two parameters:
   </TabItem>
 </Tabs>
 
-The contract will take some time to respond, as the `sign` method starts recursively calling itself in order to wait while the **MPC service** signs the payload.
+The contract will take some time to respond, as the `sign` method starts recursively calling itself waiting for the **MPC service** to sign the transaction.
 
 <details>
 <summary> A Contract Recursively Calling Itself? </summary>
 
-NEAR smart contracts are unable to halt execution and await the completion of a process. To solve this, one can make the contract call itself again and again checking on each iteration if the result is ready.
+NEAR smart contracts are unable to halt execution and await the completion of a process. To solve this, one can make the contract call itself again and again checking on each iteration to see if the result is ready.
 
-Note that each call will take one block, and thus result on ~1s of waiting. After some time the contract will either return a result - since somebody external provided it - or run out of GAS waiting.
-
-</details>
-
-<details>
-<summary> What is an MPC Service? </summary>
-
-MPC (multi-party computation) allows independent actors to do shared computations on private information, without revealing secrets to each-other.
-
-NEAR uses its own MPC service to safely sign transactions for other chains on behalf of the user. In practice, **no single node** on the MPC can **sign by itself** since they do **not hold the user's keys**. Instead, nodes create signature-shares which are aggregated through multiple rounds to jointly sign the payload.
-
-Generally, MPC signing services work by sharing a master key, which needs to be re-created each time a node joins or leaves. NEAR's MPC service allows for nodes to safely join and leave, without needing to re-derive a master key.
-
-If you want to learn more about how MPC works, we recommend to [**check this article**](https://www.zellic.io/blog/mpc-from-scratch/)
+**Note:** Each call will take one block which equates to ~1 second of waiting. After some time the contract will either return a result that an external party provided or return an error running out of GAS waiting.
 
 </details>
-
 
 ---
 
-## 4. Reconstructing the Signature 
+## 4. Reconstructing the Signature
 
-The MPC contract will not return the signature of the payload itself, but the elements we need to reconstruct such signature. 
+The MPC contract will not return the signature of the transaction itself, but the elements needed to reconstruct the signature.
 
 <Tabs groupId="code-tabs">
   <TabItem value="Ξ Ethereum">
@@ -164,3 +168,14 @@ Once we have reconstructed the signature, we can relay it to the corresponding n
   ```
   </TabItem>
 </Tabs>
+
+:::info
+
+⭐️ For a deep dive into the concepts of Chain Signatures see [What are Chain Signatures?](/concepts/abstraction/chain-signatures)
+
+⭐️ For complete examples of a NEAR account performing Eth transactions:
+
+- [web-app example](https://github.com/near-examples/near-multichain)
+- [component example](https://test.near.social/md1.testnet/widget/chainsig-sign-eth-tx) 
+
+:::

--- a/docs/8.abstraction/chain-signatures.md
+++ b/docs/8.abstraction/chain-signatures.md
@@ -20,7 +20,7 @@ This guide will take you through a step by step process for creating a Chain Sig
 ⭐️ For complete examples of a NEAR account performing Eth transactions:
 
 - [web-app example](https://github.com/near-examples/near-multichain)
-- [component example](https://test.near.social/md1.testnet/widget/chainsig-sign-eth-tx) 
+- [component example](https://test.near.social/bot.testnet/widget/chainsig-sign-eth-tx) 
 
 :::
 
@@ -176,6 +176,6 @@ Once we have reconstructed the signature, we can relay it to the corresponding n
 ⭐️ For complete examples of a NEAR account performing Eth transactions:
 
 - [web-app example](https://github.com/near-examples/near-multichain)
-- [component example](https://test.near.social/md1.testnet/widget/chainsig-sign-eth-tx) 
+- [component example](https://test.near.social/bot.testnet/widget/chainsig-sign-eth-tx) 
 
 :::

--- a/docs/8.abstraction/chain-signatures.md
+++ b/docs/8.abstraction/chain-signatures.md
@@ -7,87 +7,146 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {CodeTabs, Language, Github} from "@site/src/components/codetabs"
 
-Chain Signatures unlock the ability for a single account to transact across multiple blockchain protocols, giving ownership of cross-chain accounts, data, and assets to one NEAR account.
+NEAR accounts can safely control accounts across different blockchain protocols, allowing each NEAR account to have true ownership of cross-chain data and assets.
 
-In this document we cover the steps necessary to sign a transaction for another chain, we recommend you to read our [**overview of Chain Signatures**](../1.concepts/abstraction/chain-signatures.md) before, as well as some of its [**use cases**](../1.concepts/abstraction/signatures/use-case.md).
+![chain-signatures](/docs/assets/welcome-pages/chain-signatures-overview.png)
+_Diagram of a chain signature in NEAR_
 
-:::info
+There are five steps involved on Chain Signatures:
 
-See our [web-app example](https://github.com/near-examples/near-multichain) and [component example](https://test.near.social/md1.testnet/widget/chainsig-sign-eth-tx) showing how a NEAR account can create an Ethereum testnet transaction.
+1. [Deriving the Foreign Address](#1-deriving-foreigner-the-address) - Reconstruct the address that will be controlled on the target blockchain
+2. [Creating a Payload](#2-creating-the-payload) - Create the transaction / message that we want to sign for the target blockchain
+3. [Requesting a Signature](#3-requesting-the-signature) - Call the NEAR multichain contract, requesting to sign the payload
+4. [Reconstructing the Signature](#4-reconstructing-the-signature) - Reconstruct the signature from the MPC service's response
+5. [Relaying the Signed Payload](#5-relaying-the-signature) - The signed payload is then sent to the destination chain for execution.
 
+:::info Looking for examples?
+See our [web-app example](https://github.com/near-examples/near-multichain) and [component example](https://test.near.social/md1.testnet/widget/chainsig-sign-eth-tx) showing how a NEAR account can create transactions on Ethereum.
 ::: 
 
 ---
 
-## Create the Payload
-The first step is to use Chain Signatures is to construct a payload (transaction, message, data, etc.) for the target blockchain platform. This variates depending on the target blockchain, but in general, it's a hash of the message or transaction to be signed.
+## 1. Deriving the Foreign Address
+
+Chain Signatures use [`derivation paths`](../1.concepts/abstraction/chain-signatures.md#one-account-multiple-chains) to represent accounts on the target blockchain.
+
+The external address can be deterministically derived from the NEAR's address (e.g. `ana.near`), a derivation path (a string such as `ethereum-1`, `ethereum-2`, etc), and the MPC service's public key.
+
+We recommend to use our example code to derive the address, as it's a complex process that involves hashing and encoding: 
+
+<Tabs groupId="code-tabs">
+  <TabItem value="Ξ Ethereum">
+    <Github language="js"
+      url="https://github.com/near-examples/near-multichain/blob/main/src/index.js" start="24" end="28" />
+  </TabItem>
+
+  <TabItem value="₿ Bitcoin">
+
+  ```js
+  console.log("Coming soon...")
+  ```
+
+  </TabItem>
+</Tabs>
+
+:::tip
+The same NEAR account and path will always produce the same address on the target blockchain.
+
+- `influencer.testnet` + `ethereum-1` = `0x1b48b83a308ea4beb845db088180dc3389f8aa3b`
+- `influencer.testnet` + `ethereum-2` = `0x99c5d3025dc736541f2d97c3ef3c90de4d221315`
+:::
+
+---
+
+## 2. Creating the Payload
+Constructing the payload to be signed (transaction, message, data, etc.) variates depending on the target blockchain, but in general, it's just the hash of the message or transaction to be signed.
 
 <Tabs groupId="code-tabs">
   <TabItem value="Ξ Ethereum">
     <Github language="js"
       url="https://github.com/near-examples/near-multichain/blob/main/src/ethereum.js"
-      start="18" end="40" />
-
-</TabItem>
-
-<TabItem value="₿ Bitcoin">
-
-```js
-console.log("Coming soon...")
-```
-
-</TabItem>
-
+      start="24" end="46" />
+  </TabItem>
+  <TabItem value="₿ Bitcoin">
+  ```js
+  console.log("Coming soon...")
+  ```
+  </TabItem>
 </Tabs>
 
 ---
 
-## Request & Reconstruct a Signature 
-Once a payload is created and ready to sign, a signature request is made by calling `sign` on the [MPC smart contract](../1.concepts/abstraction/chain-signatures.md#2-signature-request). 
+## 3. Requesting the Signature 
+Once the payload is created and ready to be signed, a signature request is made by calling `sign` on the [MPC smart contract](https://github.com/near/mpc-recovery/blob/develop/contract/src/lib.rs#L298). 
 
-The method expects the `payload` to be signed for the target blockchain, and a `path` representing the account that should be used to sign the payload (learn more [here](../1.concepts/abstraction/chain-signatures.md#2-signature-request)).
+The method expects two parameters: 
+  1. The `payload` to be signed for the target blockchain
+  2. The derivation `path` for the account we want to use to sign the payload.
 
 <Tabs groupId="code-tabs">
   <TabItem value="Ξ Ethereum">
     <Github language="js"
       url="https://github.com/near-examples/near-multichain/blob/main/src/index.js"
-      start="49" end="54" />
+      start="60" end="64" />
+  </TabItem>
 
-</TabItem>
+  <TabItem value="₿ Bitcoin">
 
-<TabItem value="₿ Bitcoin">
+  ```js
+  console.log("Coming soon...")
+  ```
 
-```js
-console.log("Coming soon...")
-```
-
-</TabItem>
-
+  </TabItem>
 </Tabs>
 
-The contract will take some time to respond, as it needs to wait for the [`MPC signing service`](../1.concepts/abstraction/chain-signatures.md#3-mpc-signing-service). Once finished, the result will not be the signature on itself, but the elements needed to reconstruct the signature. 
+The contract will take some time to respond, as the `sign` method starts recursively calling itself in order to wait while the **MPC service** signs the payload.
+
+<details>
+<summary> A Contract Recursively Calling Itself? </summary>
+
+NEAR smart contracts are unable to halt execution and await the completion of a process. To solve this, one can make the contract call itself again and again checking on each iteration if the result is ready.
+
+Note that each call will take one block, and thus result on ~1s of waiting. After some time the contract will either return a result - since somebody external provided it - or run out of GAS waiting.
+
+</details>
+
+<details>
+<summary> What is an MPC Service? </summary>
+
+MPC (multi-party computation) allows independent actors to do shared computations on private information, without revealing secrets to each-other.
+
+NEAR uses its own MPC service to safely sign transactions for other chains on behalf of the user. In practice, **no single node** on the MPC can **sign by itself** since they do **not hold the user's keys**. Instead, nodes create signature-shares which are aggregated through multiple rounds to jointly sign the payload.
+
+Generally, MPC signing services work by sharing a master key, which needs to be re-created each time a node joins or leaves. NEAR's MPC service allows for nodes to safely join and leave, without needing to re-derive a master key.
+
+If you want to learn more about how MPC works, we recommend to [**check this article**](https://www.zellic.io/blog/mpc-from-scratch/)
+
+</details>
+
+
+---
+
+## 4. Reconstructing the Signature 
+
+The MPC contract will not return the signature of the payload itself, but the elements we need to reconstruct such signature. 
 
 <Tabs groupId="code-tabs">
   <TabItem value="Ξ Ethereum">
     <Github language="js"
       url="https://github.com/near-examples/near-multichain/blob/main/src/ethereum.js"
-      start="49" end="57" />
+      start="48" end="60" />
+  </TabItem>
+  <TabItem value="₿ Bitcoin">
 
-</TabItem>
-
-<TabItem value="₿ Bitcoin">
-
-```js
-console.log("Coming soon...")
-```
-
-</TabItem>
-
+  ```js
+  console.log("Coming soon...")
+  ```
+  </TabItem>
 </Tabs>
 
 ---
 
-## Relaying the Signature
+## 5. Relaying the Signature
 
 Once we have reconstructed the signature, we can relay it to the corresponding network. This will once again vary depending on the target blockchain.
 
@@ -95,16 +154,13 @@ Once we have reconstructed the signature, we can relay it to the corresponding n
   <TabItem value="Ξ Ethereum">
     <Github fname="index.js" language="js"
       url="https://github.com/near-examples/near-multichain/blob/main/src/ethereum.js"
-      start="43" end="47" />
+      start="63" end="67" />
+  </TabItem>
 
-</TabItem>
+  <TabItem value="₿ Bitcoin">
 
-<TabItem value="₿ Bitcoin">
-
-```js
-console.log("Coming soon...")
-```
-
-</TabItem>
-
+  ```js
+  console.log("Coming soon...")
+  ```
+  </TabItem>
 </Tabs>


### PR DESCRIPTION
"Learn" now reads closer to a blog-post (I think this is the general direction we will want from now on for Learn), while "Build" has all the technical details, while still explaining enough of the concepts