### PR TITLE
Fix spelling of testnet in account-id page

### DIFF
--- a/docs/1.concepts/protocol/account-id.md
+++ b/docs/1.concepts/protocol/account-id.md
@@ -55,13 +55,13 @@ Another advantage of named accounts is that they can create **sub-accounts** of 
     - `account.near` **cannot** create `sub.another-account.near`
 5. Accounts have **no control** over their sub-account, they are different entities
 
-Anyone can create a `.near` or `.testnet` account, you just to call the `create_account` method of the corresponding top-level account - `tesnet` on testnet, and `near` on mainnet.
+Anyone can create a `.near` or `.testnet` account, you just to call the `create_account` method of the corresponding top-level account - `testnet` on testnet, and `near` on mainnet.
 
 <details>
 
 <summary> 🧑‍💻 Technical: How to create a named account  </summary>
 
-Named accounts are created by calling the `create_account` method of the network's top-level account - `tesnet` on testnet, and `near` on mainnet. 
+Named accounts are created by calling the `create_account` method of the network's top-level account - `testnet` on testnet, and `near` on mainnet. 
 
 ```bash
 near call testnet create_account '{"new_account_id": "new-acc.testnet", "new_public_key": "ed25519:<data>"}' --deposit 0.00182 --accountId funding-account.testnet


### PR DESCRIPTION
By looking at the code examples (`near call testnet create_account ...`), it seem to me that the occurrences of the word `tesnet` should be replaced with `testnet`.