### PR TITLE
Update testnet MPC contract to `v5.multichain-mpc-dev.testnet`

### DIFF
--- a/docs/2.build/1.chain-abstraction/chain-signatures.md
+++ b/docs/2.build/1.chain-abstraction/chain-signatures.md
@@ -46,7 +46,7 @@ _Diagram of a chain signature in NEAR_
 
 If you want to try things out, these are the smart contracts available on `testnet`:
 
-- `multichain-testnet-2.testnet`: MPC signer contract
+- `v5.multichain-mpc-dev.testnet`: MPC signer contract
 - `canhazgas.testnet`: [Multichain Gas Station](multichain-gas-relayer/gas-station.md) contract
 - `nft.kagi.testnet`: [NFT Chain Key](nft-keys.md) contract
 


### PR DESCRIPTION
I believe this is the one we want to point folks to. See context in #1961 