### PR TITLE
update gatweay references 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at social@near.org. All
+reported by contacting the project team at privacy@near.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/docs/1.concepts/basics/protocol.md
+++ b/docs/1.concepts/basics/protocol.md
@@ -30,7 +30,7 @@ NEAR is a technical marvel, offering built-in features such as named accounts an
 
 ### ⭐ Simple to Use 
 1. Use [**named accounts**](../protocol/account-model.md) like `alice.near`
-2. Simple sign-up: make an account using [email](https://near.org/signup) or [telegram](https://web.telegram.org/k/#@herewalletbot)
+2. Simple sign-up: make an account using [email](https://dev.near.org/signup) or [telegram](https://web.telegram.org/k/#@herewalletbot)
 3. Transactions are **fast** _(~1.3s transactions)_ and **cheap** _(< 1¢ in fees)_
 4. You don't need to buy crypto thanks to **built-in account abstraction**
 5. [Access Keys](../protocol/access-keys.md) make it safe and easy to use.

--- a/docs/1.concepts/basics/validators.md
+++ b/docs/1.concepts/basics/validators.md
@@ -46,7 +46,7 @@ You can read more about our consensus strategy on our <a href="https://github.co
 
 The Chunk-Only Producer is a more accessible role with lower hardware and token requirements. This new role will allow the network's validator number to grow, creating more opportunities to earn rewards and secure the NEAR Ecosystem. 
 
-[Chunk-Only Producers](https://pages.near.org/papers/the-official-near-white-paper/#economics) are solely responsible for [producing chunks](https://pages.near.org/papers/nightshade/#nightshade) (parts of the block from a shard, see [Nightshade](https://pages.near.org/papers/nightshade/) for more detail) in one shard (a partition on the network). Because Chunk-Only Producers only need to validate one shard, they can run the validator node on a 8-Core CPU, with 16GB of RAM, and 500 GB SSD of storage.
+[Chunk-Only Producers](https://pages.near.org/papers/the-official-near-white-paper/#economics) are solely responsible for [producing chunks](https://pages.near.org/papers/nightshade/#nightshade) (parts of the block from a shard, see [Nightshade](https://near.org/papers/nightshade/) for more detail) in one shard (a partition on the network). Because Chunk-Only Producers only need to validate one shard, they can run the validator node on a 8-Core CPU, with 16GB of RAM, and 500 GB SSD of storage.
 
 Like Validators, Chunk-Only Producers will receive, at minimum, 4.5% annual rewards. If less than 100% of the tokens on the network is staked, Chunk-Only Producers stand to earn even more annual rewards. For more details about the Validator’s economics, please check out [NEAR’s Economics Explained](https://near.org/blog/near-protocol-economics/).
 

--- a/docs/1.concepts/protocol/account-id.md
+++ b/docs/1.concepts/protocol/account-id.md
@@ -8,7 +8,7 @@ NEAR accounts are identified by a unique address, which take one of two forms:
 2. [**Named addresses**](#named-address), which are simpler to remember and act as domains (e.g. `alice.near`)
 
 :::tip Searching to create an account?
-You have multiple ways to create an account, you can [sign-up using your email](https://near.org/), get a mobile wallet through [telegram](https://web.telegram.org/k/#@herewalletbot), or create a [web wallet](https://app.mynearwallet.com).
+You have multiple ways to create an account, you can [sign-up using your email](https://dev.near.org/signup) (note: email-based accounts currently have limited ability to transfer funds or sign transactions), get a mobile wallet through [telegram](https://web.telegram.org/k/#@herewalletbot), or create a [web wallet](https://app.mynearwallet.com).
 :::
 
 ---

--- a/docs/1.concepts/protocol/account-model.md
+++ b/docs/1.concepts/protocol/account-model.md
@@ -14,7 +14,7 @@ By signing [transactions](./transactions.md) with their account, users can:
 4. Help onboard new users by **covering the costs** of their transactions (gas fees)
 
 :::tip Want to create an account?
-You have multiple ways to create an account, you can [sign-up using your email](https://near.org/), get a mobile wallet through [telegram](https://web.telegram.org/k/#@herewalletbot), or create a [web wallet](https://app.mynearwallet.com).
+You have multiple ways to create an account, you can [sign-up using your email](https://dev.near.org/signup) (note: email-based accounts currently have limited ability to transfer funds or sign transactions), get a mobile wallet through [telegram](https://web.telegram.org/k/#@herewalletbot), or create a [web wallet](https://app.mynearwallet.com).
 :::
 
 ---

--- a/docs/2.build/1.chain-abstraction/multichain-gas-relayer/multichain-server.md
+++ b/docs/2.build/1.chain-abstraction/multichain-gas-relayer/multichain-server.md
@@ -89,4 +89,4 @@ For Solana it would be closer to 20-30 seconds (0.4 second block time, 1 block c
 
 L2 real finality times can over a day for finality unless we trust a centralized sequencer for soft confirmations, which may be as fast as a few seconds as in the case of [zksync era](https://era.zksync.io/docs/reference/concepts/finality.html#instant-confirmations).
 
-The difference between optimistic or soft confirmations vs real finality is something we are considering. We may get better finalized guarantees when the [Eigenlayer-Near Partnership is live](https://pages.near.org/blog/near-foundation-and-eigen-labs-partner-to-enable-faster-cheaper-web3-transactions-for-ethereum-rollups-via-eigenlayer/). 3-4 second finality for all ETH L2s is much more manageable.
+The difference between optimistic or soft confirmations vs real finality is something we are considering. We may get better finalized guarantees when the [Eigenlayer-Near Partnership is live](https://near.org/blog/near-foundation-and-eigen-labs-partner-to-enable-faster-cheaper-web3-transactions-for-ethereum-rollups-via-eigenlayer/). 3-4 second finality for all ETH L2s is much more manageable.

--- a/docs/2.build/3.near-components/anatomy/bos-components.md
+++ b/docs/2.build/3.near-components/anatomy/bos-components.md
@@ -66,10 +66,10 @@ This will set up some boilerplate code to execute the GraphQL query, add the que
 in your playground and then call that query, extract the data and render it using the
 render data function.
 
-Once you have the NEAR component code, you can test it out by going to [the sandbox](https://near.org/sandbox),
-pasting the generated code, and then selecting <kbd>Component Preview</kbd>.
+Once you have the NEAR component code, you can test it out by going to [Jutsu](https://app.jutsu.ai/),
+pasting the generated code, and enabling <kbd>Live Preview</kbd>.
 Next, you can create a nice UI over this boilerplate code, and publish your new NEAR component.
 
 #### Component Examples
 
-- [Activity Feed widget](https://near.org/near/widget/ComponentDetailsPage?src=roshaan.near/widget/user-activity-feed&tab=source) running on [near.org](https://near.org)
+- [Activity Feed widget](https://near.org/near/widget/ComponentDetailsPage?src=roshaan.near/widget/user-activity-feed&tab=source) running on [dev.near.org](https://dev.near.org)

--- a/docs/2.build/3.near-components/anatomy/notifications.md
+++ b/docs/2.build/3.near-components/anatomy/notifications.md
@@ -76,7 +76,7 @@ While there is no standard for notifications, we recommend using the following t
   });
 ```
 
-**Note**: currently, only near.org implements custom notifications
+**Note**: currently, only dev.near.org implements custom notifications
 
 </TabItem>
 

--- a/docs/2.build/3.near-components/environment.md
+++ b/docs/2.build/3.near-components/environment.md
@@ -17,9 +17,6 @@ If you plan to collaborate with multiple people, we recommend you to check [this
 ## Web Tools
 The quickest way to start building NEAR Components is by using one of the online tools. They are great for taking your first steps, while they let you find other developers and components in the NEAR ecosystem.
 
-#### [NEAR Sandbox](https://near.org/sandbox)
-The [near website](https://near.org/) contains its own [sandbox editor](https://near.org/sandbox). The sandbox allows you to code, preview and deploy your components directly from your browser.
-
 #### [Jutsu.ai](https://jutsu.ai)
 [Jutsu.ai](https://jutsu.ai) is a web IDE made for NEAR developers. It contains examples and tutorials to help onboarding you.
 

--- a/docs/2.build/3.near-components/what-is.md
+++ b/docs/2.build/3.near-components/what-is.md
@@ -502,4 +502,4 @@ For a working example visit the [deployed NEAR Component](https://near.social/za
 
 
 ## Next Steps
-Build and deploy your first components without leaving the browser. Go to https://near.org/sandbox , create an account and start building!
+Build and deploy your first components without leaving the browser. Go to https://app.jutsu.ai/, create an account and start building!

--- a/docs/2.build/6.data-infrastructure/query-api/intro.md
+++ b/docs/2.build/6.data-infrastructure/query-api/intro.md
@@ -57,7 +57,7 @@ QueryAPI stores all the indexer logic and schemas used to provision the database
 Whenever you interact with the QueryAPI NEAR component, in the background it's making an RPC query to `queryapi.dataplatform.near`,
 where a smart contract stores all of your indexer logic as well as your schemas.
 
-For example, if you select the _feed-indexer_ and click on [**View indexer**](https://near.org/dataplatform.near/widget/QueryApi.App?selectedIndexerPath=dataplatform.near/feed-indexer) you'll see all the details about an indexer that powers the [near.org](https://near.org)'s main posts feed.
+For example, if you select the _feed-indexer_ and click on [**View indexer**](https://near.org/dataplatform.near/widget/QueryApi.App?selectedIndexerPath=dataplatform.near/feed-indexer) you'll see all the details about an indexer that powers the Activity Page on [dev.near.org](https://dev.near.org).
 You're free to review the JavaScript code of the indexer function, or check the SQL that defines the database schema.
 
 

--- a/docs/3.tutorials/near-components/bos-loader.md
+++ b/docs/3.tutorials/near-components/bos-loader.md
@@ -31,9 +31,9 @@ In this article you'll learn how to develop, test, and deploy BOS components usi
 
 6. Run `bos-loader <youraccount.near> --path src` (or run from `src` folder)
 
-7. Open https://near.org/flags, and set the loader URL to `http://127.0.0.1:3030`.
+7. Open https://dev.near.org/flags, and set the loader URL to `http://127.0.0.1:3030`.
 
-8. Open `https://near.org/<youraccount.near>/widget/<component name>` (case sensitive)
+8. Open `https://dev.near.org/<youraccount.near>/widget/<component name>` (case sensitive)
 
    :::info
    If you're testing on `testnet`, use your testnet account and open https://test.near.org instead.

--- a/docs/4.tools/indexer4explorer.md
+++ b/docs/4.tools/indexer4explorer.md
@@ -108,7 +108,7 @@ Find more information about our [BigQuery solution here](../2.build/6.data-infra
 
 This is if you make queries to Explorer DB in response to API requests that your users make on your application. There are various options that you can explore:
 1. If you are working with token balances, including $NEAR, fungible or non-fungible tokens, consider using [Enhanced API](https://www.pagoda.co/enhanced-api) hosted by Pagoda, or run it yourself using https://github.com/near/near-enhanced-api-server and https://github.com/near/near-microindexers 
-2. Use NEAR QueryAPI – serverless indexers and GraphQL endpoints: https://near.org/s/p?a=nearpavel.near&b=97029570
+2. Use NEAR QueryAPI – serverless indexers and GraphQL endpoints: https://dev.near.org/s/p?a=nearpavel.near&b=97029570
 3. Use NEAR Lake Indexer. Create an indexer using [Rust](https://github.com/near/near-lake-framework-rs), [JavaScript](https://github.com/near/near-lake-framework-js). There are other languages supported by community, [try this search](https://github.com/search?q=near-lake-framework&type=repositories).
 4. Consider other indexer solutions built by the community
 

--- a/docs/6.integrations/faq.md
+++ b/docs/6.integrations/faq.md
@@ -287,7 +287,7 @@ We use a simple binary serialization format that's deterministic: https://borsh.
 - Whitepaper
 
   - General overview at [The Beginner's Guide to the NEAR Blockchain](https://near.org/blog/the-beginners-guide-to-the-near-blockchain)
-  - [NEAR Whitepaper](https://pages.near.org/papers/the-official-near-white-paper/)
+  - [NEAR Whitepaper](https://near.org/papers/the-official-near-white-paper/)
 
 - Github
   - https://www.github.com/near

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -716,8 +716,8 @@ const sidebar = {
       "items": [
         {
           "type": "link",
-          "label": "near.org Web Editor",
-          "href": "https://near.org/sandbox"
+          "label": "dev.near.org Web Editor",
+          "href": "https://dev.near.org/sandbox"
         },
         {
           "type": "link",


### PR DESCRIPTION
update gatweay references to dev.near.org and prefer Jutsu over dev.near.org/sandbox