### PR TITLE
document `ShardCongested` error on tx submission

### DIFF
--- a/docs/5.api/rpc/transactions.md
+++ b/docs/5.api/rpc/transactions.md
@@ -192,6 +192,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
       <td>
         <ul>
           <li>See <code>error.cause.info</code> for details</li>
+          <li>If <code>error.cause.info</code> is <code>ShardCongested</code></li>, resubmit the identical transaction. (Consider adding a priority fee once [NEP-541](https://github.com/near/NEPs/pull/541) is released.)
         </ul>
       </td>
     </tr>
@@ -200,7 +201,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
       <td>Transaction was routed, but has not been recorded on chain in 10 seconds.</td>
       <td>
         <ul>
-          <li> Re-submit the request with the identical transaction (in NEAR Protocol unique transactions apply exactly once, so if the previously sent transaction gets applied, this request will just return the known result, otherwise, it will route the transaction to the chain once again)</li>
+          <li> Resubmit the request with the identical transaction (in NEAR Protocol unique transactions apply exactly once, so if the previously sent transaction gets applied, this request will just return the known result, otherwise, it will route the transaction to the chain once again)</li>
           <li>Check that your transaction is valid</li>
           <li>Check that the signer account id has enough tokens to cover the transaction fees (keep in mind that some tokens on each account are locked to cover the storage cost)</li>
         </ul>
@@ -1313,6 +1314,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
       <td>
         <ul>
           <li>See <code>error.cause.info</code> for details</li>
+          <li>If <code>error.cause.info</code> is <code>ShardCongested</code></li>, resubmit the identical transaction. (Consider adding a priority fee once [NEP-541](https://github.com/near/NEPs/pull/541) is released.)
         </ul>
       </td>
     </tr>
@@ -1321,7 +1323,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
       <td>Transaction was routed, but has not been recorded on chain in 10 seconds.</td>
       <td>
         <ul>
-          <li> Re-submit the request with the identical transaction (in NEAR Protocol unique transactions apply exactly once, so if the previously sent transaction gets applied, this request will just return the known result, otherwise, it will route the transaction to the chain once again)</li>
+          <li> Resubmit the request with the identical transaction (in NEAR Protocol unique transactions apply exactly once, so if the previously sent transaction gets applied, this request will just return the known result, otherwise, it will route the transaction to the chain once again)</li>
           <li>Check that your transaction is valid</li>
           <li>Check that the signer account id has enough tokens to cover the transaction fees (keep in mind that some tokens on each account are locked to cover the storage cost)</li>
         </ul>


### PR DESCRIPTION
Add the ShardCongested error to the exhaustive list of possible return values in `send_tx` and `broadcast_tx_async`.

This error is introduced with https://github.com/near/nearcore/pull/11419 and neither in mainnet nor testnet, yet. But it's better to be ahead with documentation than behind.