### PR TITLE
Update chain-signatures.md

### DIFF
--- a/docs/2.build/1.chain-abstraction/chain-signatures.md
+++ b/docs/2.build/1.chain-abstraction/chain-signatures.md
@@ -46,7 +46,7 @@ _Diagram of a chain signature in NEAR_
 
 If you want to try things out, these are the smart contracts available on `testnet`:
 
-- `v2.multichain-mpc.testnet`: MPC signer contract
+- `v2.multichain-mpc.testnet`: [MPC signer](https://github.com/near/mpc/tree/v0.2.0/contract) contract, latest release, made up of 8 MPC nodes
 - `canhazgas.testnet`: [Multichain Gas Station](multichain-gas-relayer/gas-station.md) contract
 - `nft.kagi.testnet`: [NFT Chain Key](nft-keys.md) contract
 


### PR DESCRIPTION
#1961 

Don't believe there is reason to add v5.multichain-mpc-dev.testnet here in the docs, it can be added to MPC chainsig readme @volovyks 