### PR TITLE
expanded BOS section. added warning to all BOS pages

### DIFF
--- a/docs/2.build/3.near-components/anatomy/bos-components.md
+++ b/docs/2.build/3.near-components/anatomy/bos-components.md
@@ -4,6 +4,14 @@ title: Historical data
 sidebar_label: Handling Historical data
 ---
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 Building components that handle historical blockchain data require dedicated solutions that manage the data and reduce the latency of requests, as it's not possible to scan the whole blockchain when a user makes a request.
 
 A simple solution for developers building on NEAR is using [QueryAPI](../environment.md), a fully managed solution to build indexer functions, extract on-chain data, store it in a database, and be able to query it using GraphQL endpoints.

--- a/docs/2.build/3.near-components/anatomy/builtin-components.md
+++ b/docs/2.build/3.near-components/anatomy/builtin-components.md
@@ -3,6 +3,14 @@ id: builtin-components
 title: List of Native Components
 ---
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 import {WidgetEditor} from "@site/src/components/widget-editor"
 
 A list of all the built-in components to be used on Near Components.

--- a/docs/2.build/3.near-components/anatomy/near.md
+++ b/docs/2.build/3.near-components/anatomy/near.md
@@ -7,6 +7,14 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {WidgetEditor} from "@site/src/components/widget-editor"
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 The components can use the `Near` object to interact with smart contracts in the NEAR blockchain. There are three methods:
 
 - [`Near.view`](#nearview)

--- a/docs/2.build/3.near-components/anatomy/notifications.md
+++ b/docs/2.build/3.near-components/anatomy/notifications.md
@@ -6,6 +6,14 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {WidgetEditor} from "@site/src/components/widget-editor"
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 Applications such as [NEAR Social](https://near.social) and the [NEAR Dev Portal](https://dev.near.org/) allow components to send notifications to their users.
 
 Notifications are great to inform users in real time that something has happened, and can be [easily incorporated into any web app](../../../3.tutorials/near-components/push-notifications.md).

--- a/docs/2.build/3.near-components/anatomy/social.md
+++ b/docs/2.build/3.near-components/anatomy/social.md
@@ -5,6 +5,14 @@ title: Social Interactions
 
 import {WidgetEditor} from "@site/src/components/widget-editor"
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 NEAR components can natively communicate with the [SocialDB smart contract](https://github.com/NearSocial/social-db) (currently deployed at [social.near](https://nearblocks.io/address/social.near)).
 
 The `SocialDB` is a contract that stores `key-value` pairs, and is used mostly to store social-related data, such as `posts`, `likes`, or `profiles`.

--- a/docs/2.build/3.near-components/anatomy/state.md
+++ b/docs/2.build/3.near-components/anatomy/state.md
@@ -6,6 +6,14 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {WidgetEditor} from "@site/src/components/widget-editor"
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 Borrowing from React, Near Components use hooks such as [**`useState`**](#state) and [**`useEffect`**](#useeffect-hook) to handle the state's logic, and [**props**](#props) to receive parameters.
 
 Near Components are stored in the blockchain, for which you will use the `NEAR VM` to [retrieve and execute them in the browser](../../4.web3-apps/integrate-components.md).

--- a/docs/2.build/3.near-components/anatomy/web-methods.md
+++ b/docs/2.build/3.near-components/anatomy/web-methods.md
@@ -5,6 +5,14 @@ title: Web Browser Methods
 
 import {WidgetEditor} from "@site/src/components/widget-editor"
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 NEAR Components have access to classic web methods that enable them to:
 - [Fetch](#fetch) data from external sources.
 - [Cache](#cache) values to avoid redundant computations.

--- a/docs/2.build/3.near-components/bos-gateway.md
+++ b/docs/2.build/3.near-components/bos-gateway.md
@@ -3,6 +3,14 @@ id: bos-gateway
 title: Using components on WebApps
 ---
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 In order to use the components you create in a WebApp you need to use what is known as the `NEAR VM`. This virtual machine helps you to easily fetch components from the blockchain and transform them into executable code.
 
 There are two possible scenarios:

--- a/docs/2.build/3.near-components/environment.md
+++ b/docs/2.build/3.near-components/environment.md
@@ -3,6 +3,14 @@ id: dev-environment
 title: Choose your Dev Environment
 ---
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 The environments in which you can develop `Components` are divided into two categories:
 
 - [Web Tools](#web-tools): Online tools that allow you to quickly start building and sharing components.

--- a/docs/2.build/3.near-components/what-is.md
+++ b/docs/2.build/3.near-components/what-is.md
@@ -8,6 +8,14 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {WidgetEditor} from "@site/src/components/widget-editor"
 
+:::warning What is the state of BOS (NEAR Components)?
+
+We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
+
+See [here](/build/web3-apps/frontend#bos-socialvm) for more info
+
+:::
+
 NEAR Components are a new way to build web applications. They are composable, reusable and decentralized.
 
 ![img](/docs/assets/welcome-pages/bos-landing.png)

--- a/docs/2.build/4.web3-apps/frontend.md
+++ b/docs/2.build/4.web3-apps/frontend.md
@@ -58,29 +58,20 @@ To learn more, you can check other decentralized hosting options like [Fleek](ht
 -->
 
 ## BOS (SocialVM)
-
-The BOS VM was an interesting experiment that ultimately had too many security issues and technical limitations to be considered a valid option for building robust web apps moving forward. An example Social VM website is [near.social](https://near.social).
-
-:::info What about BOS?
+:::warning What is the state of BOS?
 
 We no longer recommend building on BOS due to its limited capabilities and discontinued security maintenance. Developers with active projects on BOS are encouraged to migrate to another deployment strategy.
 
 :::
 
-#### Pros
+BOS (UI) was an experiment in hosting UI code on chain and creating an ecosystem of composable and remixable components for dapp development.
 
-- An interesting experiment to host decentralized UI components on the blockchain.
-- All components within the community can be imported and forked.
+The use of a VM was intended to allow embedding untrusted third-party components into your experience in a way that their access to the full browser context and the ability to manipulate the behavior of your dapp was limited.
 
-#### Cons
+Unfortunately numerous exploits have been discovered and patched, and the nature of these exploits along with the quirks of javascript make it likely that this will be a continuing trend. For examples of previous discovered vulnerabilities, view the [VM changelog](https://github.com/NearSocial/VM/blob/master/CHANGELOG.md) going back to v2.5.1 paying attention to lines tagged as `FIX` on issues `Reported by BrunoModificato from OtterSec`.
 
-- Extremely limited due to proprietary React syntax and security concerns.
-- Unable to use libraries from NPM.
-- Unsupported moving forward due to security issues.
+It is not tenable to proactively discover and mitigate vulnerabilities in a comprehensive manner where the VM can be seen as providing a security guarantee. Coupling that with the significant tradeoffs in capabilities of applications built for the VM, we do not recommend continued usage of BOS as a development platform.
 
+An example BOS VM website is [near.social](https://near.social).
 
-:::tip
-
-Check [this article](integrate-components.md) to learn how to integrate BOS components to your frontend.
-
-:::
+[This article](integrate-components.md) details how BOS components could be integrated into your frontend.


### PR DESCRIPTION
I expanded the BOS section to give more information on our move away from BOS, and to remove the pros+cons which gave the impression that building on BOS was still a viable route.

I also added a warning callout to all the BOS component docs pages until we get around to removing them