### PR TITLE
temp pause crowdin translation

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -287,12 +287,12 @@ const config = {
   },
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'ko', 'vi', 'zh-CN'],
-    localeConfigs: {
-      'zh-CN': {
-        label: '简体中文',
-      },
-    },
+    // locales: ['en', 'ko', 'vi', 'zh-CN'],
+    // localeConfigs: {
+    //   'zh-CN': {
+    //     label: '简体中文',
+    //   },
+    // },
   },
 };
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -287,7 +287,7 @@ const config = {
   },
   i18n: {
     defaultLocale: 'en',
-    // locales: ['en', 'ko', 'vi', 'zh-CN'],
+    locales: ['en'],
     // localeConfigs: {
     //   'zh-CN': {
     //     label: '简体中文',


### PR DESCRIPTION
Docusaurus builds consistently break due to crowdin plugin. This PR temporarily pauses this feature until a fix or alternative solution is ready.