### PR TITLE
chore: how to enable unit-testing feature on near-sdk

### DIFF
--- a/docs/2.build/2.smart-contracts/testing/unit-test.md
+++ b/docs/2.build/2.smart-contracts/testing/unit-test.md
@@ -24,6 +24,9 @@ The tests in the [Counter Example](https://github.com/near-examples/counters) re
     <Github fname="lib.rs"
             url="https://github.com/near-examples/counters/blob/main/contract-rs/src/lib.rs"
             start="47" end="68" />
+    <Github fname="Cargo.toml"
+            url="https://github.com/near-examples/counters/blob/main/contract-rs/Cargo.toml"
+            start="18" end="19" />
   </Language>
 </CodeTabs>
 
@@ -38,6 +41,9 @@ While doing unit testing you can modify the [Environment variables](../anatomy/e
     <Github fname="lib.rs"
             url="https://github.com/near-examples/donation-examples/blob/main/contract-rs/src/lib.rs"
             start="58" end="105" />
+    <Github fname="Cargo.toml"
+            url="https://github.com/near-examples/donation-examples/blob/main/contract-rs/Cargo.toml"
+            start="18" end="19" />
   </Language>
 </CodeTabs>
 


### PR DESCRIPTION
Added link to Cargo.toml file in order to show user how to enable unit-testing feature on near-sdk