### PR TITLE
feat: do not show logo on iframe

### DIFF
--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -171,6 +171,10 @@ table+p em,
     padding: 0.8rem;
 }
 
+.navbar__item:first-of-type {
+    padding-left: .4rem;
+}
+
 .navbar__logo {
     height: 28px;
 }

--- a/website/src/theme/Navbar/Logo/index.js
+++ b/website/src/theme/Navbar/Logo/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import Logo from '@theme/Logo';
+export default function NavbarLogo() {
+
+  // if embedded in an iframe, do not show the logo
+  if (window.location !== window.parent.location) {
+    return null;
+  }
+
+  return (
+    <Logo
+      className="navbar__brand"
+      imageClassName="navbar__logo"
+      titleClassName="navbar__title text--truncate"
+    />
+  );
+}


### PR DESCRIPTION
This small commit hides the NEAR logo when docs are embedded in an `iframe`. This is going to be useful for the docs embedded on dev.near.org: https://dev.near.org/documentation 