### PR TITLE
document the new `ReceiptValidationError::ReceiptSizeExceeded`

### DIFF
--- a/docs/6.integrations/errors/error-implementation.md
+++ b/docs/6.integrations/errors/error-implementation.md
@@ -442,6 +442,11 @@ pub enum ReceiptValidationError {
     /// An error occurred while validating actions of an ActionReceipt.
     ActionsValidation(ActionsValidationError),
     /// Receipt is bigger than the limit.
+    /// ReceiptSizeExceeded means that there was a receipt above the size limit (currently 4MiB).
+    /// NEAR will refuse to execute receipts that are above the size limit.
+    /// The most likely source of such receipts would be cross-contract calls with a lot of large actions
+    /// (contract deployment, function call with large args, etc).
+    /// This error means that the user has to adjust their contract to generate smaller receipts.
     ReceiptSizeExceeded { size: u64, limit: u64 },
 }
 ```

--- a/docs/6.integrations/errors/error-implementation.md
+++ b/docs/6.integrations/errors/error-implementation.md
@@ -441,6 +441,8 @@ pub enum ReceiptValidationError {
     NumberInputDataDependenciesExceeded { number_of_input_data_dependencies: u64, limit: u64 },
     /// An error occurred while validating actions of an ActionReceipt.
     ActionsValidation(ActionsValidationError),
+    /// Receipt is bigger than the limit.
+    ReceiptSizeExceeded { size: u64, limit: u64 },
 }
 ```
 
@@ -466,6 +468,9 @@ ReceiptValidationError::NumberInputDataDependenciesExceeded { number_of_input_da
 "The number of input data dependencies {} exceeded the limit {} in an ActionReceipt"
 
 ReceiptValidationError::ActionsValidation(e) 
+
+ReceiptValidationError::ReceiptSizeExceeded { size, limit }
+"The size of the receipt exceeded the limit: {} > {}",
 ```
 
 


### PR DESCRIPTION
Add information about the new `ReceiptValidationError::ReceiptSizeExceeded` error added in https://github.com/near/nearcore/pull/11492.

I'm new to this repo, I looked at `ReceiptValidationError::InvalidDataReceiverId` and put information about my error in the same places.

I also have a longer description of the error that users could find more useful, but I'm not sure where to put it. Can I replace the comment saying "/// Receipt is bigger than the limit."? Or should these docs stay in sync with the source files?

Longer description:

> `ReceiptSizeExceeded` means that there was a receipt above the size limit (currently 4MiB). NEAR will refuse to execute receipts that are above the size limit. The most likely source of such receipts would be cross-contract calls with a lot of large actions (contract deployment, function call with large args, etc).
This error means that the user has to adjust their contract to generate smaller receipts.

Refs: [zulip conversation](https://near.zulipchat.com/#narrow/stream/308695-nearone.2Fprivate/topic/partner.20request.20for.20rpc/near/455717072)