### PR TITLE
docs: added info about new status codes

### DIFF
--- a/docs/5.api/rpc/access-keys.md
+++ b/docs/5.api/rpc/access-keys.md
@@ -132,6 +132,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -140,6 +141,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td rowspan="6">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -150,6 +152,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>INVALID_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> is invalid</td>
       <td>
         <ul>
@@ -159,6 +162,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNKNOWN_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> has not been found while viewing since the account has not been created or has been already deleted</td>
       <td>
         <ul>
@@ -169,6 +173,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNKNOWN_ACCESS_KEY</td>
+      <td>200</td>
       <td>The requested <code>public_key</code> has not been found while viewing since the public key has not been created or has been already deleted</td>
       <td>
         <ul>
@@ -179,6 +184,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNAVAILABLE_SHARD</td>
+      <td>200</td>
       <td>The node was unable to found the requested data because it does not track the shard where data is present</td>
       <td>
         <ul>
@@ -188,6 +194,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>NO_SYNCED_BLOCKS</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -199,6 +206,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -210,6 +218,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -448,6 +457,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -456,6 +466,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td rowspan="5">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -466,6 +477,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>INVALID_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> is invalid</td>
       <td>
         <ul>
@@ -475,6 +487,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNKNOWN_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> has not been found while viewing since the account has not been created or has been already deleted</td>
       <td>
         <ul>
@@ -485,6 +498,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNAVAILABLE_SHARD</td>
+      <td>200</td>
       <td>The node was unable to find the requested data because it does not track the shard where data is present</td>
       <td>
         <ul>
@@ -494,6 +508,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>NO_SYNCED_BLOCKS</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -505,6 +520,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -516,6 +532,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -669,6 +686,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -677,6 +695,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -687,6 +706,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -698,6 +718,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -709,6 +730,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -862,6 +884,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -870,6 +893,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -880,6 +904,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -891,6 +916,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -902,6 +928,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>

--- a/docs/5.api/rpc/block-chunk.md
+++ b/docs/5.api/rpc/block-chunk.md
@@ -283,6 +283,7 @@ Here is the exhaustive list of the error variants that can be returned by `block
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -291,6 +292,7 @@ Here is the exhaustive list of the error variants that can be returned by `block
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -301,6 +303,7 @@ Here is the exhaustive list of the error variants that can be returned by `block
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -312,6 +315,7 @@ Here is the exhaustive list of the error variants that can be returned by `block
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -323,6 +327,7 @@ Here is the exhaustive list of the error variants that can be returned by `block
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -532,6 +537,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -540,6 +546,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -550,6 +557,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -561,6 +569,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -572,6 +581,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -737,6 +747,7 @@ Here is the exhaustive list of the error variants that can be returned by `chunk
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -745,6 +756,7 @@ Here is the exhaustive list of the error variants that can be returned by `chunk
     <tr>
       <td rowspan="4">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -755,6 +767,7 @@ Here is the exhaustive list of the error variants that can be returned by `chunk
     </tr>
     <tr>
       <td>UNKNOWN_CHUNK</td>
+      <td>200</td>
       <td>The requested chunk can't be found in a database</td>
       <td>
         <ul>
@@ -765,6 +778,7 @@ Here is the exhaustive list of the error variants that can be returned by `chunk
     </tr>
     <tr>
       <td>INVALID_SHARD_ID</td>
+      <td>200</td>
       <td>Provided <code>shard_id</code> does not exist</td>
       <td>
         <ul>
@@ -774,6 +788,7 @@ Here is the exhaustive list of the error variants that can be returned by `chunk
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested chunk is not in the database yet</td>
       <td>
         <ul>
@@ -785,6 +800,7 @@ Here is the exhaustive list of the error variants that can be returned by `chunk
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -796,6 +812,7 @@ Here is the exhaustive list of the error variants that can be returned by `chunk
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>

--- a/docs/5.api/rpc/contracts.md
+++ b/docs/5.api/rpc/contracts.md
@@ -123,6 +123,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -131,6 +132,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td rowspan="5">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -141,6 +143,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>INVALID_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> is invalid</td>
       <td>
         <ul>
@@ -150,6 +153,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNKNOWN_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> has not been found while viewing since the account has not been created or has been already deleted</td>
       <td>
         <ul>
@@ -160,6 +164,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNAVAILABLE_SHARD</td>
+      <td>200</td>
       <td>The node was unable to find the requested data because it does not track the shard where data is present</td>
       <td>
         <ul>
@@ -169,6 +174,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>NO_SYNCED_BLOCKS</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -180,6 +186,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -191,6 +198,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -344,6 +352,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -352,6 +361,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -362,6 +372,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -373,6 +384,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -384,6 +396,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -508,6 +521,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -516,6 +530,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td rowspan="6">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -526,6 +541,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>INVALID_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> is invalid</td>
       <td>
         <ul>
@@ -535,6 +551,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNKNOWN_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> has not been found while viewing since the account has not been created or has been already deleted</td>
       <td>
         <ul>
@@ -545,6 +562,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>NO_CONTRACT_CODE</td>
+      <td>200</td>
       <td>The account does not have any <code>contract</code> deployed on it</td>
       <td>
         <ul>
@@ -555,6 +573,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNAVAILABLE_SHARD</td>
+      <td>200</td>
       <td>The node was unable to find the requested data because it does not track the shard where data is present</td>
       <td>
         <ul>
@@ -564,6 +583,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>NO_SYNCED_BLOCKS</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -575,6 +595,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -586,6 +607,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -900,6 +922,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -908,6 +931,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td rowspan="7">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -918,6 +942,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>INVALID_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> is invalid</td>
       <td>
         <ul>
@@ -927,6 +952,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNKNOWN_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> has not been found while viewing since the account has not been created or has been already deleted</td>
       <td>
         <ul>
@@ -937,6 +963,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>NO_CONTRACT_CODE</td>
+      <td>200</td>
       <td>The account does not have any <code>contract</code> deployed on it</td>
       <td>
         <ul>
@@ -947,6 +974,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>TOO_LARGE_CONTRACT_STATE</td>
+      <td>200</td>
       <td>The requested contract state is too large to be returned from this node (the default limit is 50kb of state size)</td>
       <td>
         <ul>
@@ -957,6 +985,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>UNAVAILABLE_SHARD</td>
+      <td>200</td>
       <td>The node was unable to find the requested data because it does not track the shard where data is present</td>
       <td>
         <ul>
@@ -966,6 +995,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     </tr>
     <tr>
       <td>NO_SYNCED_BLOCKS</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -977,6 +1007,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -988,6 +1019,7 @@ Here is the exhaustive list of the error variants that can be returned by `view_
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -1139,6 +1171,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -1147,6 +1180,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -1157,6 +1191,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -1168,6 +1203,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -1179,6 +1215,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -1313,6 +1350,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -1321,6 +1359,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -1331,6 +1370,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>NOT_SYNCED_YET</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -1342,6 +1382,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -1353,6 +1394,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -1538,6 +1580,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -1546,6 +1589,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     <tr>
       <td rowspan="7">HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -1556,6 +1600,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     </tr>
     <tr>
       <td>INVALID_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> is invalid</td>
       <td>
         <ul>
@@ -1565,6 +1610,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     </tr>
     <tr>
       <td>UNKNOWN_ACCOUNT</td>
+      <td>200</td>
       <td>The requested <code>account_id</code> has not been found while viewing since the account has not been created or has been already deleted</td>
       <td>
         <ul>
@@ -1575,6 +1621,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     </tr>
     <tr>
       <td>NO_CONTRACT_CODE</td>
+      <td>200</td>
       <td>The requested <code>contract_code</code> has not been found while viewing</td>
       <td>
         <ul>
@@ -1585,6 +1632,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     </tr>
     <tr>
       <td>CONTRACT_EXECUTION_ERROR</td>
+      <td>200</td>
       <td>The execution of the view function call failed (crashed, run out of the default 200 TGas limit, etc)</td>
       <td>
         <ul>
@@ -1594,6 +1642,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     </tr>
     <tr>
       <td>UNAVAILABLE_SHARD</td>
+      <td>200</td>
       <td>The node was unable to find the requested data because it does not track the shard where data is present</td>
       <td>
         <ul>
@@ -1603,6 +1652,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     </tr>
     <tr>
       <td>NO_SYNCED_BLOCKS</td>
+      <td>200</td>
       <td>The node is still syncing and the requested block is not in the database yet</td>
       <td>
         <ul>
@@ -1614,6 +1664,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -1625,6 +1676,7 @@ Here is the exhaustive list of the error variants that can be returned by `call_
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>

--- a/docs/5.api/rpc/gas.md
+++ b/docs/5.api/rpc/gas.md
@@ -167,6 +167,7 @@ Here is the exhaustive list of the error variants that can be returned by `gas_p
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -175,6 +176,7 @@ Here is the exhaustive list of the error variants that can be returned by `gas_p
     <tr>
       <td>HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -186,6 +188,7 @@ Here is the exhaustive list of the error variants that can be returned by `gas_p
     <tr>
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -197,6 +200,7 @@ Here is the exhaustive list of the error variants that can be returned by `gas_p
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>

--- a/docs/5.api/rpc/maintenance-windows.md
+++ b/docs/5.api/rpc/maintenance-windows.md
@@ -109,6 +109,7 @@ Here is the exhaustive list of the error variants that can be returned by `maint
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -117,6 +118,7 @@ Here is the exhaustive list of the error variants that can be returned by `maint
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>

--- a/docs/5.api/rpc/network.md
+++ b/docs/5.api/rpc/network.md
@@ -282,6 +282,7 @@ Here is the exhaustive list of the error variants that can be returned by `statu
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -290,6 +291,7 @@ Here is the exhaustive list of the error variants that can be returned by `statu
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -405,6 +407,7 @@ Here is the exhaustive list of the error variants that can be returned by `netwo
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -413,6 +416,7 @@ Here is the exhaustive list of the error variants that can be returned by `netwo
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -1356,6 +1360,7 @@ Here is the exhaustive list of the error variants that can be returned by `valid
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -1364,6 +1369,7 @@ Here is the exhaustive list of the error variants that can be returned by `valid
     <tr>
       <td>HANDLER_ERROR</td>
       <td>UNKNOWN_EPOCH</td>
+      <td>200</td>
       <td>An epoch for the provided block can't be found in a database</td>
       <td>
         <ul>
@@ -1376,6 +1382,7 @@ Here is the exhaustive list of the error variants that can be returned by `valid
     <tr>
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -1387,6 +1394,7 @@ Here is the exhaustive list of the error variants that can be returned by `valid
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>

--- a/docs/5.api/rpc/protocol.md
+++ b/docs/5.api/rpc/protocol.md
@@ -323,6 +323,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -331,6 +332,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -633,6 +635,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -641,6 +644,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>HANDLER_ERROR</td>
       <td>UNKNOWN_BLOCK</td>
+      <td>200</td>
       <td>The requested block has not been produced yet or it has been garbage-collected (cleaned up to save space on the RPC node)</td>
       <td>
         <ul>
@@ -652,6 +656,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>

--- a/docs/5.api/rpc/transactions.md
+++ b/docs/5.api/rpc/transactions.md
@@ -180,6 +180,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -188,6 +189,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>INVALID_TRANSACTION</td>
+      <td>200</td>
       <td>An error happened during transaction execution</td>
       <td>
         <ul>
@@ -199,6 +201,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     </tr>
     <tr>
       <td>TIMEOUT_ERROR</td>
+      <td>408</td>
       <td>Transaction was routed, but has not been recorded on chain in 10 seconds.</td>
       <td>
         <ul>
@@ -211,6 +214,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -222,6 +226,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -416,6 +421,7 @@ Here is the exhaustive list of the error variants that can be returned by `tx` m
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -424,6 +430,7 @@ Here is the exhaustive list of the error variants that can be returned by `tx` m
     <tr>
       <td rowspan="3">HANDLER_ERROR</td>
       <td>INVALID_TRANSACTION</td>
+      <td>200</td>
       <td>An error happened during transaction execution</td>
       <td>
         <ul>
@@ -433,6 +440,7 @@ Here is the exhaustive list of the error variants that can be returned by `tx` m
     </tr>
     <tr>
       <td>UNKNOWN_TRANSACTION</td>
+      <td>200</td>
       <td>The requested transaction is not available on the node since it might have not been recorded on the chain yet or has been garbage-collected</td>
       <td>
         <ul>
@@ -444,6 +452,7 @@ Here is the exhaustive list of the error variants that can be returned by `tx` m
     </tr>
     <tr>
       <td>TIMEOUT_ERROR</td>
+      <td>408</td>
       <td>It was unable to wait for the transaction status for reasonable time</td>
       <td>
         <ul>
@@ -455,6 +464,7 @@ Here is the exhaustive list of the error variants that can be returned by `tx` m
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -466,6 +476,7 @@ Here is the exhaustive list of the error variants that can be returned by `tx` m
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -794,6 +805,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -802,6 +814,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td rowspan="3">HANDLER_ERROR</td>
       <td>INVALID_TRANSACTION</td>
+      <td>200</td>
       <td>An error happened during transaction execution</td>
       <td>
         <ul>
@@ -811,6 +824,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>UNKNOWN_TRANSACTION</td>
+      <td>200</td>
       <td>The requested transaction is not available on the node since it might have not been recorded on the chain yet or has been garbage-collected</td>
       <td>
         <ul>
@@ -822,6 +836,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     </tr>
     <tr>
       <td>TIMEOUT_ERROR</td>
+      <td>408</td>
       <td>It was unable to wait for the transaction status for reasonable time</td>
       <td>
         <ul>
@@ -833,6 +848,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr className="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -844,6 +860,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -961,6 +978,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -969,6 +987,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>HANDLER_ERROR</td>
       <td>UNKNOWN_RECEIPT</td>
+      <td>200</td>
       <td>The receipt with the given <code>receipt_id</code> was never observed on the node</td>
       <td>
         <ul>
@@ -980,6 +999,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -991,6 +1011,7 @@ Here is the exhaustive list of the error variants that can be returned by `EXPER
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>
@@ -1126,6 +1147,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -1134,6 +1156,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     <tr class="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -1303,6 +1326,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
         <code>error.name</code>
       </th>
       <th>ERROR_CAUSE<br /><code>error.cause.name</code></th>
+      <th>Status Code</th>
       <th>Reason</th>
       <th>Solution</th>
     </tr>
@@ -1311,6 +1335,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     <tr>
       <td rowspan="2">HANDLER_ERROR</td>
       <td>INVALID_TRANSACTION</td>
+      <td>200</td>
       <td>An error happened during transaction execution</td>
       <td>
         <ul>
@@ -1322,6 +1347,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     </tr>
     <tr>
       <td>TIMEOUT_ERROR</td>
+      <td>408</td>
       <td>Transaction was routed, but has not been recorded on chain in 10 seconds.</td>
       <td>
         <ul>
@@ -1334,6 +1360,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     <tr class="stripe">
       <td>REQUEST_VALIDATION_ERROR</td>
       <td>PARSE_ERROR</td>
+      <td>400</td>
       <td>Passed arguments can't be parsed by JSON RPC server (missing arguments, wrong format, etc.)</td>
       <td>
         <ul>
@@ -1345,6 +1372,7 @@ Here is the exhaustive list of the error variants that can be returned by `broad
     <tr>
       <td>INTERNAL_ERROR</td>
       <td>INTERNAL_ERROR</td>
+      <td>500</td>
       <td>Something went wrong with the node itself or overloaded</td>
       <td>
         <ul>


### PR DESCRIPTION
This PR is adding an information about new possible status codes that can be returned by `jsonrpc`

From now on, `jsonrpc` will start returning other HTTP codes than 200 OK for some errors:
* On internal server error it will return 500
* On timeout error it will return 408
* On request validation error will return 400

Changes were introduced in https://github.com/near/nearcore/pull/11806 and https://github.com/near/nearcore/pull/11822