### PR TITLE
Fix quickstart

### DIFF
--- a/docs/2.build/2.smart-contracts/quickstart.md
+++ b/docs/2.build/2.smart-contracts/quickstart.md
@@ -293,7 +293,7 @@ Having our account created, we can now deploy the contract:
   <TabItem value="short" label="Short">
 
   ```bash
-  near deploy <created-account> build/release/hello.wasm
+  near deploy <created-account> build/hello_near.wasm
   ```
 
   </TabItem>


### PR DESCRIPTION
The wasm file location is different in the deploy the contract section:

Error:
   0: Failed to open or read the file: "build/release/hello.wasm".
   1: No such file or directory (os error 2)