### PR TITLE
Update Build Commands in Documentation

### DIFF
--- a/docs/2.build/2.smart-contracts/quickstart.md
+++ b/docs/2.build/2.smart-contracts/quickstart.md
@@ -269,6 +269,7 @@ If you encounter issues with Docker or prefer not to use Docker for building con
   ```bash
   npm run build
   ```
+  Or
 
   ```bash
   npm run build --no-docker
@@ -281,8 +282,10 @@ If you encounter issues with Docker or prefer not to use Docker for building con
   ```bash
   cargo near build
   ```
-    ```bash
-    cargo near build --no-docker
+  Or
+  
+  ```bash
+  cargo near build --no-docker
   ```
 
   </TabItem>

--- a/docs/2.build/2.smart-contracts/quickstart.md
+++ b/docs/2.build/2.smart-contracts/quickstart.md
@@ -262,13 +262,16 @@ Remember that you can create a named account through any wallet (i.e. [MyNearWal
 
 ## Build the Contract
 
-When you are ready to create a build of the contract run a one-line command depending on your environment.
-
+If you encounter issues with Docker or prefer not to use Docker for building contracts, you can pass the --no-docker flag to certain commands (where applicable). 
 <Tabs groupId="cli-tabs">
   <TabItem value="js" label="🌐 JavaScript">
 
   ```bash
   npm run build
+  ```
+
+  ```bash
+  npm run build --no-docker
   ```
 
   </TabItem>
@@ -277,6 +280,9 @@ When you are ready to create a build of the contract run a one-line command depe
 
   ```bash
   cargo near build
+  ```
+    ```bash
+    cargo near build --no-docker
   ```
 
   </TabItem>


### PR DESCRIPTION
**Description:**
This PR updates the documentation to include accurate and detailed build commands for both JavaScript and Rust projects on NEAR.

**Related Issue:**
[[Link to issue discussing this update]](https://github.com/near/docs/issues/2356)