### PR TITLE
Update Deployment Documentation to Use Correct Contract Filename (`generated.wasm`) with Full and Short Rust Commands

### DIFF
--- a/docs/2.build/2.smart-contracts/quickstart.md
+++ b/docs/2.build/2.smart-contracts/quickstart.md
@@ -329,7 +329,7 @@ Having our account created, we can now deploy the contract:
   <TabItem value="short" label="Short">
 
   ```bash
-  near deploy <created-account> ./target/wasm32-unknown-unknown/release/hello.wasm
+  near deploy <created-account> ./target/wasm32-unknown-unknown/release/<generated-file>.wasm
   ```
 
   </TabItem>
@@ -337,7 +337,7 @@ Having our account created, we can now deploy the contract:
   <TabItem value="full" label="Full">
 
   ```bash
-  near contract deploy <created-account> use-file ./target/wasm32-unknown-unknown/release/hello.wasm without-init-call network-config testnet sign-with-keychain send
+  near contract deploy <created-account> use-file ./target/wasm32-unknown-unknown/release/<generated-file>.wasm without-init-call network-config testnet sign-with-keychain send
   ```
 
   </TabItem>


### PR DESCRIPTION
**Description:**  
This PR updates the deployment documentation to reflect the correct contract filename (`generated.wasm`), and includes both full and short command examples for deploying a contract in Rust.

**Changes:**  
- Updated the filename in the deployment command to `generated.wasm` instead of `hello.wasm`.
- Added both full and short commands for deploying the contract in Rust.

**Commands:**

🦀 **Rust**  
Full Command:  
```bash
near deploy <created-account> ./target/wasm32-unknown-unknown/release/generated.wasm
```

Short Command:  
```bash
near deploy <created-account> ./target/wasm32-unknown-unknown/release/generated.wasm
```