### PR TITLE
docs: fixed name of the API Update bos-ethersjs-best-practices.md

### DIFF
--- a/docs/3.tutorials/near-components/bos-ethersjs-best-practices.md
+++ b/docs/3.tutorials/near-components/bos-ethersjs-best-practices.md
@@ -156,7 +156,7 @@ const loadTokensData = () => {
   });
 
   tokens.map((tokenId) => {
-    const tokenData = loadCoingeckData(tokenId);
+    const tokenData = loadCoingeckoData(tokenId);
     // save balance of every token to the state
     State.update({ [tokenId]: { ...tokenData, ...state[tokenId] } });
   });


### PR DESCRIPTION
<img width="418" alt="Снимок экрана 2024-12-21 в 19 53 53" src="https://github.com/user-attachments/assets/9c235733-6140-4f59-85f6-6830f8bdcdd4" />

The correct name of the API is **CoinGecko**, not Coingeck.

Fixed.