### PR TITLE
docs: fix typo Update validators.md

### DIFF
--- a/docs/1.concepts/basics/validators.md
+++ b/docs/1.concepts/basics/validators.md
@@ -39,7 +39,7 @@ You can view the list of currently active validators on platforms like [NEAR-STA
 
 We don't need GPU support as we are a POS chain and we require very little compute power.
 
-You can read more about our consensus strategy on our <a href="https://github.com/near/wiki/blob/master/Archive/validators/about.md" target="_blank" rel="noopener noreferrer">Validator Quickstart</a> and <a href="https://github.com/near/wiki/blob/master/Archive/validators/faq.md" target="_blank" rel="noopener noreferrer">Staking FA</a>.
+You can read more about our consensus strategy on our <a href="https://github.com/near/wiki/blob/master/Archive/validators/about.md" target="_blank" rel="noopener noreferrer">Validator Quickstart</a> and <a href="https://github.com/near/wiki/blob/master/Archive/validators/faq.md" target="_blank" rel="noopener noreferrer">Staking FAQ</a>.
 </blockquote>
 
 ## Block & Chunk producers


### PR DESCRIPTION
<img width="688" alt="Снимок экрана 2024-12-21 в 20 28 35" src="https://github.com/user-attachments/assets/126dfac1-5b6b-4b90-a284-c144a334e9a7" />

In "Staking FA," the letter Q is missing; the full term is "FAQ" (Frequently Asked Questions).

Fixed.