### PR TITLE
docs: Fixed grammar issue in Hue account creation instructions

### DIFF
--- a/docs/pagoda/alerts/webhooks.md
+++ b/docs/pagoda/alerts/webhooks.md
@@ -108,7 +108,7 @@ Select Turn On Lights
 
 Select the lights of your choosing but I will simply do all lights. 
 
-If you haven't already create and connect your Hue Account
+If you haven't already created and connected your Hue Account
 
 <img width="40%" src="/docs/pagoda/webhook14.png" />
 


### PR DESCRIPTION
### Description
I noticed a grammatical error in the instruction text where "create" should be preceded by "to" for proper phrasing.

Here's the updated sentence:

Original:
"If you haven't already create and connect your Hue Account..."

Fixed:
"If you haven't already **created** and **connected** your Hue Account..."

This should now read more clearly and be grammatically correct.