### PR TITLE
chore: update commands to latest cargo-near

### DIFF
--- a/docs/2.build/2.smart-contracts/quickstart.md
+++ b/docs/2.build/2.smart-contracts/quickstart.md
@@ -289,7 +289,7 @@ When you are ready to create a build of the contract run a one-line command depe
   
   :::info
 
-  If you encounter issues with Docker you can use the `--no-docker` flag to skip creating a reproducible build
+  If you encounter issues with Docker you can use the `non-reproducible-wasm` option to skip creating a reproducible build
 
   :::
 
@@ -319,7 +319,7 @@ Having our account created, we can now deploy the contract:
   <TabItem value="full" label="Full">
 
   ```bash
-  near contract deploy <created-account> use-file ./target/wasm32-unknown-unknown/release/hello.wasm without-init-call network-config testnet sign-with-keychain send
+  near contract deploy <created-account> use-file ./target/near/hello.wasm without-init-call network-config testnet sign-with-keychain send
   ```
 
   </TabItem>
@@ -334,7 +334,7 @@ Having our account created, we can now deploy the contract:
   <TabItem value="short" label="Short">
 
   ```bash
-  near deploy <created-account> ./target/wasm32-unknown-unknown/release/<generated-file>.wasm
+  near deploy <created-account> ./target/near/<generated-file>.wasm
   ```
 
   </TabItem>
@@ -342,7 +342,7 @@ Having our account created, we can now deploy the contract:
   <TabItem value="full" label="Full">
 
   ```bash
-  near contract deploy <created-account> use-file ./target/wasm32-unknown-unknown/release/<generated-file>.wasm without-init-call network-config testnet sign-with-keychain send
+  near contract deploy <created-account> use-file ./target/near/<generated-file>.wasm without-init-call network-config testnet sign-with-keychain send
   ```
 
   </TabItem>


### PR DESCRIPTION
with latest version of `cargo-near`:
- no longer supports `--no-docker` flag.
- produces different compiled wasm in `./target/near/<contract>.wasm` to the one found in `./target/wasm32-unknown-unknown/<contract>.wasm` deploying the later might cause errors including:
```zsh
0: Error: An error occurred during a FunctionCall Action, parameter is debug message.
     CompilationError(PrepareError(Deserialization))
```