### PR TITLE
Replace --amount with --deposit 

### DIFF
--- a/docs/3.tutorials/auction/1.3-deploy.md
+++ b/docs/3.tutorials/auction/1.3-deploy.md
@@ -114,7 +114,7 @@ We are now ready to start bidding by calling the `bid` function on the contract.
 
 ```bash
 # call the contract to bid 
-near call <contractId> bid --accountId <bidderId> --deposit 1 
+near call <contractId> bid --accountId <bidderId> --depositYocto 1 
 
 # get the highest bid
 near view <contractId> get_highest_bid

--- a/docs/3.tutorials/auction/1.3-deploy.md
+++ b/docs/3.tutorials/auction/1.3-deploy.md
@@ -114,7 +114,7 @@ We are now ready to start bidding by calling the `bid` function on the contract.
 
 ```bash
 # call the contract to bid 
-near call <contractId> bid --accountId <bidderId> --amount 1 
+near call <contractId> bid --accountId <bidderId> --deposit 1 
 
 # get the highest bid
 near view <contractId> get_highest_bid


### PR DESCRIPTION
**Description:**
This PR updates the CLI command to replace the --amount flag with --deposit. This change improves clarity and aligns terminology with the application's intended functionality.

**Changes:**
Replaced  instance of **--amount** with **--deposit** in the codebase.

_**Related Issue :**_ https://github.com/near/docs/issues/2397
