### PR TITLE
Fix typo Update bos-loader.md

### DIFF
--- a/docs/3.tutorials/near-components/bos-loader.md
+++ b/docs/3.tutorials/near-components/bos-loader.md
@@ -5,7 +5,7 @@ title: BOS Loader
 
 # BOS Loader
 
-In this article you'll learn how to develop, test, and deploy BOS components using CLI tools. You can use this workflow to tap into the colaboration, pull-request, and other GitHub benefits while still deploying components to the BOS. 
+In this article you'll learn how to develop, test, and deploy BOS components using CLI tools. You can use this workflow to tap into the collaboration, pull-request, and other GitHub benefits while still deploying components to the BOS. 
 
 [BOS Component Loader](https://github.com/near/bos-loader) serves a local directory of component files as a JSON payload properly formatted to be plugged into a BOS `redirectMap`. When paired with a viewer configured to call out to this loader, it enables local component development.
 


### PR DESCRIPTION
## Title: Fix Typo in bos-loader.md

### Description:
This pull request addresses a typo in the `bos-loader.md` file within the `docs/3.tutorials/near-components` directory. The typo occurred in the description where **"colaboration"** was used instead of **"collaboration"**.

### Affected File:
- `docs/3.tutorials/near-components/bos-loader.md`

### Changes:
- **Before**:
  - "You can use this workflow to tap into the colaboration, pull-request, and other GitHub benefits..."
  
- **After**:
  - "You can use this workflow to tap into the collaboration, pull-request, and other GitHub benefits..."

### Motivation:
The typo "colaboration" was corrected to its proper form "collaboration" to maintain accurate spelling and professionalism in the documentation.

### How to Test:
This is a documentation change only. No testing is required.

### Related Issues:
- No related issues.

### Impact:
- This change improves the accuracy and professionalism of the documentation.

---

Thank you for reviewing this change! Please let me know if you have any questions or need further modifications.
