### PR TITLE
Adds "AI Agents" to Not Found page

### DIFF
--- a/website/src/theme/NotFound/Content/index.js
+++ b/website/src/theme/NotFound/Content/index.js
@@ -67,6 +67,9 @@ export default function NotFoundContent({ className }) {
                       <a href="/smart-contracts/what-is">
                         <li>Smart Contracts</li>
                       </a>
+                      <a href="/ai/introduction">
+                        <li>AI Agents</li>
+                      </a>
                       <a href="/web3-apps/what-is">
                         <li>Web3 Applications</li>
                       </a>


### PR DESCRIPTION
Ran into this because of a broken shade agent link (https://github.com/NearDeFi/shade-agent-template/pull/7), and noticed there is no suggested route to building AI agents.

Just a suggestion; maybe there should be a different ordering or there is better place to start