### PR TITLE
Minor Documentation Fixes: Typo Corrections in Intents and Gas Protocol Docs

### DIFF
--- a/docs/chain-abstraction/intents/overview.md
+++ b/docs/chain-abstraction/intents/overview.md
@@ -131,7 +131,7 @@ See [Create a Solver](solvers.md) for more details on how these solvers work.
 
 When a user accepts a quote from the Solver Network, the intent begins execution. This is done by the solver performing a contract call (`execute_intents`) to the Intents smart contract on NEAR ([`intents.near`](https://nearblocks.io/address/intents.near)) and passing the intent details. 
 
-The NEAR Intents contract fullfills the request and (if needed) uses multi-chain bridge to settle an intent cross-chain. The Intent smart contract also verifies state changes and ensures the intent is settled correctly, reporting the outcome to the originating user/agent.
+The NEAR Intents contract fulfills the request and (if needed) uses multi-chain bridge to settle an intent cross-chain. The Intent smart contract also verifies state changes and ensures the intent is settled correctly, reporting the outcome to the originating user/agent.
 
 <!-- TODO: add link to smart contract docs -->
 

--- a/docs/protocol/gas.md
+++ b/docs/protocol/gas.md
@@ -180,7 +180,7 @@ Congestion control between shards gets tricky when transactions have much more g
 
 The other inefficiency comes from the refund receipts that prior to version 78 have been created for essentially every function call. While each of them is relatively cheap to execute, in the sum they were a significant part of the global traffic on NEAR Protocol.
 
-To read more about the deicsion to introduce this fee, pleaes take a look at the [NEP-536](https://github.com/near/NEPs/pull/536)
+To read more about the deicsion to introduce this fee, please take a look at the [NEP-536](https://github.com/near/NEPs/pull/536)
 
 </details>
 


### PR DESCRIPTION


Description:  
This pull request makes minor corrections to the documentation in two files:

- docs/chain-abstraction/intents/overview.md:  
  Fixed a typo by changing fulfills to fulfills for consistency and clarity in the description of the NEAR Intents contract.

- docs/protocol/gas.md:  
  Corrected a typo by changing pleases to please in the sentence referring to NEP-536 for further reading.

