### PR TITLE
Add domain ID and currently supported signature schemes

### DIFF
--- a/docs/chain-abstraction/chain-signatures.md
+++ b/docs/chain-abstraction/chain-signatures.md
@@ -96,12 +96,13 @@ In practice, the external address is deterministically derived using the NEAR ad
 
 A deployed multichain smart contract ([v1.signer](https://nearblocks.io/address/v1.signer)) is used to request signatures for transactions on other blockchains.
 
-This contract has [a `sign` method](https://github.com/near/mpc/blob/01f33ed0a2a2c4c24ef49a2f36df3b20aa400816/libs/chain-signatures/contract/src/lib.rs#L242) that takes these two parameters:
+This contract has [a `sign` method](https://github.com/near/mpc/blob/01f33ed0a2a2c4c24ef49a2f36df3b20aa400816/libs/chain-signatures/contract/src/lib.rs#L242) that takes these three parameters:
 
   1. The `payload` (transaction or transaction hash) to be signed for the target blockchain.
-  2. The `path` that identifies the account you want to use to sign the transaction.
+  2. The `path` that identifies the account to be used to sign the transaction.
+  3. The `domain_id` as an integer that identifies the signature scheme to be used for generating the signature. Currently this can be `0` for Secp256k1 or `1` for Ed25519.
 
-For example, a user could request a signature to `send 0.1 ETH to 0x060f1...` **(transaction)** using the `ethereum-1` account **(path)**.
+For example, a user could request a signature to `send 0.1 ETH to 0x060f1...` **(transaction)** using the `ethereum-1` account **(path)** with `0` (Secp256k1) as **domain ID**.
 
 After a request is made, the `sign` method will [yield execution](/blog/yield-resume) waiting while the [MPC signing service](#multi-party-computation-service) signs the transaction.
 


### PR DESCRIPTION
- Add the specification of `domain_ID` as input for the `sign` `method.
- Add the currently supported signature schemes.