### PR TITLE
Add `tip` about  signature schemes and supported blockchains

### DIFF
--- a/docs/chain-abstraction/chain-signatures.md
+++ b/docs/chain-abstraction/chain-signatures.md
@@ -108,6 +108,10 @@ After a request is made, the `sign` method will [yield execution](/blog/yield-re
 
 Once the signature is ready, the contract resumes computation and returns it to the user. This signature is a valid signed transaction that can be readily sent to the target blockchain to be executed.
 
+:::tip
+The `sign` method currently supports both Secp256k1 and Ed25519 signature schemes which enables signing transactions for the vast majority of the well-known blockchains including Bitcoin, Ethereum, Solana, BNB chain, Ton, or Stellar. In the future, the MPC participants can add more signature schemes via the `vote_add_domains` method.  
+:::
+
 <hr class="subsection" />
 
 ### Multi-Party Computation Service


### PR DESCRIPTION
Add a note as a `tip` specifying the currently supported signature schemes with the implied supported blockchains. Also comment on the possibility of more sign schemes being added in the future.