### PR TITLE
Migrate Near Drop example into Tutorial: What drops are & how to create a drop contract

### DIFF
--- a/docs/tutorials/examples/near-drop.md
+++ b/docs/tutorials/examples/near-drop.md
@@ -1,303 +1,82 @@
 ---
 id: near-drop
-title: Near Drop
-description: "NEAR Drop is a smart contract that allows users to create token drops ($NEAR, Fungible and Non-Fungible Tokens), and link them to specific private keys. Whoever has the private key can claim the drop into an existing account, or ask the contract to create a new one for them."
+title: "NEAR Drop: Create claimable token drops with FunctionCall keys"
+description: "What drops are, when to use them, how they work under the hood with FunctionCall keys, and how to create/claim NEAR, FT, and NFT drops."
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import {CodeTabs, Language, Github} from "@site/src/components/codetabs"
+A **drop** lets you lock value (Ⓝ, FT, or NFT) behind a **public key** and allow **whoever holds the private key** to claim it. This pattern enables smooth onboarding (share a link/QR → user claims) and gift campaigns without asking the recipient to pre-fund gas or already have an account.
 
-NEAR Drop is a smart contract that allows users to create token drops ($NEAR, Fungible and Non-Fungible Tokens), and link them to specific private keys. Whoever has the private key can claim the drop into an existing account, or ask the contract to create a new one for them.
-
-Particularly, it shows:
-
-1. How to create a token drops (NEAR, FT and NFT)
-2. How to leverage Function Call keys for enabling amazing UX
-
-:::tip
-
-This example showcases a simplified version of the contract that both [Keypom](https://keypom.xyz/) and the [Token Drop Utility](https://dev.near.org/tools?tab=linkdrops) use to distribute tokens to users
-
-:::
+This tutorial explains the concept, trade-offs, and the two claim flows (to an existing account or creating a brand-new account), using the simplified contract behind community tools like linkdrops.
 
 ---
 
-## Contract Overview
+## When (and when not) to use drops
 
-The contract exposes 3 methods to create drops of NEAR tokens, FT, and NFT. To claim the tokens, the contract exposes two methods, one to claim in an existing account, and another that will create a new account and claim the tokens into it.
+**Great for**
+- **Onboarding**: give newcomers value + an account in one step.
+- **Campaigns / rewards**: distribute coupons, POAP-style NFTs, or micro-grants.
+- **Gasless feel**: the **contract** owns a temporary FunctionCall key, so claimers don’t need to pre-fund gas.
 
-This contract leverages NEAR unique feature of [FunctionCall keys](../../protocol/access-keys.md), which allows the contract to create new accounts and claim tokens on behalf of the user.
-
-Imagine Alice want to drop some NEAR to Bob:
-
-1. Alice will call `create_near_drop` passing some NEAR amount, and a **Public** Access Key
-2. The Contract will check if Alice attached enough tokens and create the drop
-3. The Contract will add the `PublicKey` as a `FunctionCall Key` to itself, that **only allow to call the claim methods**
-4. Alice will give the `Private Key` to Bob
-5. Bob will use the Key to sign a transaction calling the `claim_for` method
-6. The Contract will check if the key is linked to a drop, and if it is, it will send the drop
-
-It is important to notice that, in step (5), Bob will be using the Contract's account to sign the transaction, and not his own account. Remember that in step (3) the contract added the key to itself, meaning that anyone with the key can call the claim methods in the name of the contract.
-
-<details>
-
-<summary>Contract's interface</summary>
-
-#### `create_near_drop(public_keys, amount_per_drop)`
-Creates `#public_keys` drops, each with `amount_per_drop` NEAR tokens on them
-
-#### `create_ft_drop(public_keys, ft_contract, amount_per_drop)`
-Creates `#public_keys` drops, each with `amount_per_drop` FT tokens, corresponding to the `ft_contract`
-
-#### `create_nft_drop(public_key, nft_contract)`
-Creates a drop with an NFT token, which will come from the `nft_contract`
-
-#### `claim_for(account_id)`
-Claims a drop, which will be sent to the existing `account_id`
-
-#### `create_account_and_claim(account_id)`
-Creates the `account_id`, and then drops the tokens into it
-
-</details>
+**Consider alternatives**
+- If you already know the recipients, a **direct transfer** (FT/NFT) can be simpler.
+- For large lists with allowlists, consider **Merkle airdrops** or claim-by-proof approaches.
+- If you need **multiple assets per claim**, this example doesn’t mix NEAR+FT+NFT in a single drop (pick one type per drop).
 
 ---
 
-## Contract's State
+## How a drop works (mental model)
 
-We can see in the contract's state that the contract keeps track of different `PublicKeys`, and links them to a specific `DropId`, which is simply an identifier for a `Drop` (see below). 
+1. **Create**: The creator calls `create_near_drop` / `create_ft_drop` / `create_nft_drop`, attaching enough deposit to cover storage and the assets. They pass one or more **public keys**.
+2. **Key install**: The contract stores a mapping `PublicKey → DropId` and **adds each key** to **its own account** as a **FunctionCall key** restricted to the claim methods.
+3. **Share**: The creator shares the **private key** that corresponds to the public key.
+4. **Claim**: The claimer uses that private key to sign a call to `claim_for` (send to an **existing** account) or `create_account_and_claim` (create a **new** account, then send).
+5. **Finalize**: The contract verifies the key is valid for a remaining drop, transfers the asset, **decrements** the drop counter, and can clean up when it reaches zero.
 
-- `top_level_account`: The account that will be used to create new accounts, generally it will be `testnet` or `mainnet`
-- `next_drop_id`: A simple counter used to assign unique identifiers to each drop
-- `drop_id_by_key`: A `Map` between `PublicKey` and `DropId`, which allows the contract to know what drops are claimable by a given key
-- `drop_by_id`: A simple `Map` that links each `DropId` with the actual `Drop` data.
-
-<Github fname="lib.rs" language="rust"
-      url="https://github.com/near-examples/near-drop/blob/main/src/lib.rs"
-      start="22" end="29" />
+**Important:** the claimer is effectively signing *as the contract account* via that FunctionCall key, but they are **limited to claim methods only**.
 
 ---
 
-## Drop Types
+## Contract surface (concept)
 
-There are 3 types of drops, which differ in what the user will receive when they claims the corresponding drop - NEAR, fungible tokens (FTs) or non-fungible tokens (NFTs).
+- **Create**
+  - `create_near_drop(public_keys, amount_per_drop)`
+  - `create_ft_drop(public_keys, ft_contract, amount_per_drop)`
+  - `create_nft_drop(public_key, nft_contract)`
+- **Claim**
+  - `claim_for(account_id)` — send to an **existing** account
+  - `create_account_and_claim(account_id)` — **create** the account, then send
 
-<Language value="rust" language="rust">
-<Github fname="drop_types.rs"
-  url="https://github.com/near-examples/near-drop/blob/main/src/drop_types.rs"
-  start="8" end="16" />
-<Github fname="near_drop.rs"
-  url="https://github.com/near-examples/near-drop/blob/main/src/near_drop.rs"
-  start="9" end="16" />
-<Github fname="ft_drop.rs"
-  url="https://github.com/near-examples/near-drop/blob/main/src/ft_drop.rs"
-  start="16" end="24" />
-<Github fname="nft_drop.rs"
-  url="https://github.com/near-examples/near-drop/blob/main/src/nft_drop.rs"
-  start="15" end="22" />
-</Language>
+**State**
+- `drop_id_by_key: PublicKey → DropId` — who can claim what
+- `drop_by_id: DropId → Drop` — amount/type/counter/metadata
+- `top_level_account` — used when creating new accounts (e.g. `testnet`)
 
-:::info
-
-Notice that in this example implementation users cannot mix drops. This is, you can either drop NEAR tokens, or FT, or NFTs, but not a mixture of them (i.e. you cannot drop 1 NEAR token and 1 FT token in the same drop)
-
-:::
+> Note: In this simplified implementation you **do not mix** asset types per drop: choose **NEAR**, **FT**, or **NFT**.
 
 ---
 
-## Create a drop
+## Security, UX, and trade-offs
 
-All `create` start by checking that the user deposited enough funds to create the drop, and then proceed to add the access keys to the contract's account as [FunctionCall Keys](../../protocol/access-keys.md).
-
-<Tabs>
-
-  <TabItem value="NEAR" label="NEAR Drop">
-    <Language value="rust" language="rust">
-      <Github fname="create_near_drop"
-        url="https://github.com/near-examples/near-drop/blob/main/src/lib.rs"
-        start="44" end="66" />
-      <Github fname="near_drop"
-        url="https://github.com/near-examples/near-drop/blob/main/src/near_drop.rs"
-        start="63" end="95" />
-    </Language>
-  </TabItem>
-  <TabItem value="FT" label="FT Drop">
-    <Language value="rust" language="rust">
-      <Github fname="create_ft_drop"
-        url="https://github.com/near-examples/near-drop/blob/main/src/lib.rs"
-        start="68" end="89" />
-      <Github fname="ft_drop"
-        url="https://github.com/near-examples/near-drop/blob/main/src/ft_drop.rs"
-        start="108" end="142" />
-    </Language>
-  </TabItem>
-  <TabItem value="NFT" label="NFT Drop">
-    <Language value="rust" language="rust">
-      <Github fname="create_nft_drop"
-        url="https://github.com/near-examples/near-drop/blob/main/src/lib.rs"
-        start="91" end="103" />
-      <Github fname="nft_drop"
-        url="https://github.com/near-examples/near-drop/blob/main/src/nft_drop.rs"
-        start="80" end="106" />
-    </Language>
-  </TabItem>
-</Tabs>
-
-<hr class="subsection" />
-
-### Storage Costs
-
-While we will not go into the details of how the storage costs are calculated, it is important to know what is being taken into account:
-
-1. The cost of storing each Drop, which will include storing all bytes associated with the `Drop` struct
-2. The cost of storing each `PublicKey -> DropId` relation in the maps
-3. Cost of storing each `PublicKey` in the account
-
-Notice that (3) is not the cost of storing the byte representation of the `PublicKey` on the state, but the cost of adding the key to the contract's account as a FunctionCall key.
+- **FunctionCall keys**: add them with **method restrictions** (only claim methods) and sensible **allowance/gas**; remove when exhausted.
+- **Key handling**: anyone with the **private key** can claim — treat it like a bearer coupon. Use **one-time keys** when possible.
+- **Storage & deposits**: creators must cover storage for (a) the drop struct, (b) the key→drop mapping, and (c) adding the key to the account.
+- **Scale**: thousands of keys mean higher storage; consider batching and a cleanup path when counters hit zero.
+- **Account creation**: the contract can create **only under `top_level_account`** (e.g., `*.testnet`). Choose it to match your network and naming plan.
 
 ---
 
-## Claim a drop
+## Quickstart (testnet)
 
-In order to claim drop, a user needs to sign a transaction using the `Private Key`, which is the counterpart of the `Public Key` that was added to the contract.
+> Keep this focused: create one NEAR drop with two keys, then see how you’d claim.
 
-All `Drops` have a `counter` which decreases by 1 each time a drop is claimed. This way, when all drops are claimed (`counter` == 0), we can remove all information from the Drop.
-
-There are two ways to claim a drop: claim for an existing account and claim for a new account. The main difference between them is that the first one will send the tokens to an existing account, while the second one will create a new account and send the tokens to it.
-
-<hr class="subsection" />
-
-<Tabs>
-  <TabItem value="existing" label="Existing Account">
-    <Language value="rust" language="rust">
-      <Github fname="claim_for"
-        url="https://github.com/near-examples/near-drop/blob/main/src/claim.rs"
-        start="11" end="14" />
-      <Github fname="internal_claim"
-        url="https://github.com/near-examples/near-drop/blob/main/src/claim.rs"
-        start="58" end="85" />
-    </Language>
-  </TabItem>
-  <TabItem value="new" label="New Account">
-    <Language value="rust" language="rust">
-      <Github fname="create_account_and_claim"
-        url="https://github.com/near-examples/near-drop/blob/main/src/claim.rs"
-        start="16" end="41" />
-      <Github fname="resolve_account_create"
-        url="https://github.com/near-examples/near-drop/blob/main/src/claim.rs"
-        start="43" end="56" />
-      <Github fname="internal_claim"
-        url="https://github.com/near-examples/near-drop/blob/main/src/claim.rs"
-        start="58" end="85" />
-    </Language>
-  </TabItem>
-</Tabs>
-
----
-
-### Testing the Contract
-
-The contract readily includes a sandbox testing to validate its functionality. To execute the tests, run the following command:
-
-<Tabs groupId="code-tabs">
-  <TabItem value="rust" label="🦀 Rust">
-  
-  ```bash
-  cargo test
-  ```
-
-  </TabItem>
-</Tabs>
-
-:::tip
-The `integration tests` use a sandbox to create NEAR users and simulate interactions with the contract.
-:::
-
----
-
-### Deploying the Contract to the NEAR network
-
-In order to deploy the contract you will need to create a NEAR account.
-
-<Tabs groupId="cli-tabs">
-  <TabItem value="short" label="Short">
-
-  ```bash
-  # Create a new account pre-funded by a faucet
-  near create-account <accountId> --useFaucet
-  ```
-  </TabItem>
-
-  <TabItem value="full" label="Full">
-
-  ```bash
-  # Create a new account pre-funded by a faucet
-  near account create-account sponsor-by-faucet-service <my-new-dev-account>.testnet autogenerate-new-keypair save-to-keychain network-config testnet create
-  ```
-  </TabItem>
-</Tabs>
-
-Then build and deploy the contract:
-
+### 0) Deploy once (minimal)
 ```bash
+# Build
 cargo near build
 
-cargo near deploy <accountId> with-init-call new json-args '{"top_level_account": "testnet"}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' network-config testnet sign-with-keychain send
-```
-
----
-
-### CLI: Interacting with the Contract
-
-To interact with the contract through the console, you can use the following commands:
-
-<Tabs groupId="cli-tabs">
-  <TabItem value="short" label="Short">
-  
-  ```bash
-  # create a NEAR drop
-  near call <account-id> create_near_drop '{"public_keys": ["ed25519:AvBVZDQrg8pCpEDFUpgeLYLRGUW8s5h57NGhb1Tc4H5q", "ed25519:4FMNvbvU4epP3HL9mRRefsJ2tMECvNLfAYDa9h8eUEa4"], "amount_per_drop": "10000000000000000000000"}' --accountId <account-id> --deposit 1 --gas 100000000000000
-
-  # create a FT drop
-  near call <account-id> create_ft_drop '{"public_keys": ["ed25519:HcwvxZXSCX341Pe4vo9FLTzoRab9N8MWGZ2isxZjk1b8", "ed25519:5oN7Yk7FKQMKpuP4aroWgNoFfVDLnY3zmRnqYk9fuEvR"], "amount_per_drop": "1", "ft_contract": "<ft-contract-account-id>"}' --accountId <account-id> --gas 100000000000000
-
-  # create a NFT drop
-  near call <account-id> create_nft_drop '{"public_key": "ed25519:HcwvxZXSCX341Pe4vo9FLTzoRab9N8MWGZ2isxZjk1b8", "nft_contract": "<nft-contract-account-id>"}' --accountId <account-id> --gas 100000000000000
-  
-  # claim to an existing account
-  # see the full version
-
-  # claim to a new account
-  # see the full version
-  ```
-  </TabItem>
-
-  <TabItem value="full" label="Full">
-  
-  ```bash
-  # create a NEAR drop
-  near contract call-function as-transaction <account-id> create_near_drop json-args '{"public_keys": ["ed25519:AvBVZDQrg8pCpEDFUpgeLYLRGUW8s5h57NGhb1Tc4H5q", "ed25519:4FMNvbvU4epP3HL9mRRefsJ2tMECvNLfAYDa9h8eUEa4"], "amount_per_drop": "10000000000000000000000"}' prepaid-gas '100.0 Tgas' attached-deposit '1 NEAR' sign-as <account-id> network-config testnet sign-with-keychain send
-
-  # create a FT drop
-  near contract call-function as-transaction <account-id> create_ft_drop json-args '{"public_keys": ["ed25519:HcwvxZXSCX341Pe4vo9FLTzoRab9N8MWGZ2isxZjk1b8", "ed25519:5oN7Yk7FKQMKpuP4aroWgNoFfVDLnY3zmRnqYk9fuEvR"], "amount_per_drop": "1", "ft_contract": "<ft-contract-account-id>"}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as <account-id> network-config testnet sign-with-keychain send
-
-  # create a NFT drop
-  near contract call-function as-transaction <account-id> create_nft_drop json-args '{"public_key": "ed25519:HcwvxZXSCX341Pe4vo9FLTzoRab9N8MWGZ2isxZjk1b8", "nft_contract": "<nft-contract-account-id>"}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as <account-id> network-config testnet sign-with-keychain send
-
-  # claim to an existing account
-  near contract call-function as-transaction <account-id> claim_for json-args '{"account_id": "<claimer-account-id>"}' prepaid-gas '30.0 Tgas' attached-deposit '0 NEAR' sign-as <account-id> network-config testnet sign-with-plaintext-private-key --signer-public-key ed25519:AvBVZDQrg8pCpEDFUpgeLYLRGUW8s5h57NGhb1Tc4H5q --signer-private-key ed25519:3yVFxYtyk7ZKEMshioC3BofK8zu2q6Y5hhMKHcV41p5QchFdQRzHYUugsoLtqV3Lj4zURGYnHqMqt7zhZZ2QhdgB send
-
-  # claim to a new account
-  near contract call-function as-transaction <account-id> create_account_and_claim json-args '{"account_id": "<claimer-account-id>"}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' sign-as <account-id> network-config testnet sign-with-plaintext-private-key --signer-public-key ed25519:4FMNvbvU4epP3HL9mRRefsJ2tMECvNLfAYDa9h8eUEa4 --signer-private-key ed25519:2xZcegrZvP52VrhehvApnx4McL85hcSBq1JETJrjuESC6v6TwTcr4VVdzxaCReyMCJvx9V4X1ppv8cFFeQZ6hJzU send
-  ```
-  </TabItem>
-</Tabs>
-
-:::note Versioning for this article
-
-At the time of this writing, this example works with the following versions:
-
-- near-cli: `0.17.0`
-- rustc: `1.82.0`
-
-:::
+# Deploy & init (top_level_account = "testnet")
+cargo near deploy <account-id> \
+  with-init-call new \
+  json-args '{"top_level_account":"testnet"}' \
+  prepaid-gas '100 Tgas' attached-deposit '0 NEAR' \
+  network-config testnet sign-with-keychain send


### PR DESCRIPTION
…te a drop contractThis PR migrates the “Near Drop” example into a focused tutorial.

- Explains the concept of drops and FunctionCall-key–based claiming
- Covers use cases, trade-offs, and security/UX considerations
- Documents the create/claim flows for NEAR, FT, and NFT drops (one type per drop)
- Provides a minimal Quickstart with near-cli / near-cli-rs commands
- Keeps the same `id: near-drop` so existing links won’t break
