### PR TITLE
Migrate Advanced XCC example into Tutorial: How to interact with any other contract on NEAR

### DIFF
--- a/docs/tutorials/examples/advanced-xcc.md
+++ b/docs/tutorials/examples/advanced-xcc.md
@@ -1,365 +1,145 @@
 ---
 id: advanced-xcc
-title: Complex Cross Contract Call
-description: "Master advanced cross-contract call patterns in NEAR Protocol, including callbacks, error handling, and complex multi-contract interactions."
+title: "Advanced XCC: Interact with any other contract on NEAR"
+description: "Core patterns for advanced cross-contract calls (XCC): batching, multi-contract parallelism, and callbacks with robust result handling."
 ---
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import {CodeTabs, Language, Github} from "@site/src/components/codetabs"
 
-This example presents 3 instances of complex cross-contract calls on the NEAR blockchain, showcasing how to batch multiple function calls to a same contract, call multiple contracts in parallel, and handle responses in the callback. It includes both the smart contract and the frontend components. 
+Cross-contract calls (**XCC**) are how a contract on NEAR talks to other contracts.  
+This tutorial focuses on *advanced* patterns you’ll actually use in production:
 
-
-:::info Simple Cross-Contract Calls
-
-Check the tutorial on how to use [simple cross-contract calls](xcc.md)
-
-:::
+- **Batch actions**: sequential, atomic calls to one receiver  
+- **Parallel calls**: fan-out to multiple receivers, join results in a callback  
+- **Callbacks**: collect the last result vs. all results, handle errors, and budget gas correctly
 
 ---
 
-## Obtaining the Cross Contract Call Example
+## When to use each pattern
 
-You have two options to start the Donation Example:
+**Batch actions (sequential, atomic)**  
+Bundle several function calls to the *same* contract. They execute in order, and if one fails the chain reverts. Use for **atomic multi-step updates** (e.g., `approve → transfer → log`).
 
-1. You can use the app through `Github Codespaces`, which will open a web-based interactive environment.
-2. Clone the repository locally and use it from your computer.
+**Parallel calls (fan-out across contracts)**  
+Trigger calls to different contracts in parallel, then combine their results. Perfect for **aggregations** (balances, metadata, oracles). One failure **does not** revert the others.
 
-| Codespaces                                                                                                                      | Clone locally                                               |
-| ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/near-examples/cross-contract-calls?quickstart=1) | 🌐 `https://github.com/near-examples/cross-contract-calls` |
+**Callbacks**  
+- **Last result**: useful in sequential batches where only the final call matters.  
+- **All results**: useful in parallel fan-out where each contract returns something.
 
 ---
 
-## Structure of the Example
+## 1. Batch actions (sequential, atomic)
 
-The smart contract is available in two flavors: Rust and JavaScript
-
-<Tabs groupId="code-tabs">
-
-  <TabItem value="js" label="🌐 JavaScript">
-
-```bash
-┌── sandbox-ts # sandbox testing
-│    ├── external-contracts
-│    │    ├── counter.wasm
-│    │    ├── guest-book.wasm
-│    │    └── hello-near.wasm
-│    └── main.ava.ts
-├── src # contract's code
-│    ├── internal
-│    │    ├── batch_actions.ts
-│    │    ├── constants.ts
-│    │    ├── multiple_contracts.ts
-│    │    ├── similar_contracts.ts
-│    │    └── utils.ts
-│    └── contract.ts
-├── package.json
-├── README.md
-└── tsconfig.json
-```
-
-  </TabItem>
-
+<Tabs groupId="lang">
   <TabItem value="rust" label="🦀 Rust">
 
-```bash
-┌── tests # sandbox testing
-│    ├── external-contracts
-│    │    ├── counter.wasm
-│    │    ├── guest-book.wasm
-│    │    └── hello-near.wasm
-│    └── main.ava.ts
-├── src # contract's code
-│    ├── batch_actions.rs
-│    ├── lib.rs
-│    ├── multiple_contracts.rs
-│    └── similar_contracts.rs
-├── Cargo.toml # package manager
-├── README.md
-└── rust-toolchain.toml
-```
+```rust
+#[near_bindgen]
+impl Contract {
+    pub fn batch_actions(&mut self, target: AccountId) -> Promise {
+        Promise::new(target.clone())
+            .function_call("step_one".into(), b"{}".to_vec(), 0, Gas(30_000_000_000_000))
+            .function_call("step_two".into(), b"{}".to_vec(), 0, Gas(30_000_000_000_000))
+            .then(
+                Self::ext(env::current_account_id())
+                    .with_static_gas(Gas(10_000_000_000_000))
+                    .on_batch_done()
+            )
+    }
 
-  </TabItem>
+    #[private]
+    pub fn on_batch_done(&self) -> Option<String> {
+        match env::promise_result(0) {
+            PromiseResult::Successful(bytes) => String::from_utf8(bytes).ok(),
+            _ => None,
+        }
+    }
+}
 
-</Tabs>
+@NearBindgen
+class Contract {
+  @call
+  batch_actions({ target }: { target: string }) {
+    const p = Near.promiseBatchCreate(target);
+    Near.promiseBatchActionFunctionCall(p, "step_one", "{}".encode(), 0n, 30_000_000_000_000n);
+    Near.promiseBatchActionFunctionCall(p, "step_two", "{}".encode(), 0n, 30_000_000_000_000n);
+    return Near.promiseThen(
+      p,
+      Near.promiseBatchCreate(Near.currentAccountId()),
+      "on_batch_done",
+      "{}".encode(),
+      0n,
+      10_000_000_000_000n,
+    );
+  }
 
----
+  @private @view
+  on_batch_done(): string | null {
+    const r = Near.promiseResult(0);
+    return r.status === 1 ? r.bufferResult.decode() : null;
+  }
+}
 
-## Smart Contract
+#[near_bindgen]
+impl Contract {
+    pub fn multiple_contracts(&self, accounts: Vec<AccountId>) -> Promise {
+        let mut p: Option<Promise> = None;
+        for a in accounts {
+            let call = Promise::new(a).function_call(
+                "get_value".into(),
+                b"{}".to_vec(),
+                0,
+                Gas(10_000_000_000_000),
+            );
+            p = Some(match p { None => call, Some(prev) => prev.and(call) });
+        }
+        p.unwrap().then(
+            Self::ext(env::current_account_id())
+                .with_static_gas(Gas(20_000_000_000_000))
+                .on_multi_done()
+        )
+    }
 
-### Batch Actions
+    #[private]
+    pub fn on_multi_done(&self) -> Vec<Result<String, String>> {
+        let n = env::promise_results_count();
+        (0..n).map(|i| match env::promise_result(i) {
+            PromiseResult::Successful(bytes) => Ok(String::from_utf8(bytes).unwrap_or_default()),
+            _ => Err("failed".into()),
+        }).collect()
+    }
+}
 
-You can aggregate multiple actions directed towards one same contract into a batched transaction.
-Methods called this way are executed sequentially, with the added benefit that, if one fails then
-they **all get reverted**.
+@NearBindgen
+class Contract {
+  @call
+  multiple_contracts({ accounts }: { accounts: string[] }) {
+    const ps = accounts.map((a) =>
+      Near.promiseBatchActionFunctionCall(
+        Near.promiseBatchCreate(a),
+        "get_value",
+        "{}".encode(),
+        0n,
+        10_000_000_000_000n
+      )
+    );
+    const joined = Near.promiseAndAll(ps);
+    return Near.promiseThen(
+      joined,
+      Near.promiseBatchCreate(Near.currentAccountId()),
+      "on_multi_done",
+      "{}".encode(),
+      0n,
+      20_000_000_000_000n,
+    );
+  }
 
-<CodeTabs>
-  <Language value="js" language="js">
-    <Github fname="contract.ts"
-          url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/contract.ts"
-          start="38" end="41" />
-    <Github fname="batch_actions.ts"
-          url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/batch_actions.ts"
-          start="5" end="17" />
-  </Language>
-  <Language value="rust" language="rust">
-    <Github fname="batch_actions.rs"
-            url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-rs/src/batch_actions.rs"
-            start="8" end="20" />
-  </Language>
-</CodeTabs>
-
-#### Getting the Last Response
-
-In this case, the callback has access to the value returned by the **last
-action** from the chain.
-
-<CodeTabs>
-  <Language value="js" language="js">
-    <Github fname="contract.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/contract.ts"
-      start="43" end="46" />
-    <Github fname="batch_actions.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/batch_actions.ts"
-      start="19" end="29" />
-    <Github fname="utils.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/utils.ts"
-      start="3" end="20" />
-  </Language>
-  <Language value="rust" language="rust">
-    <Github fname="batch_actions.rs"
-            url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-rs/src/batch_actions.rs"
-            start="22" end="35" />
-  </Language>
-</CodeTabs>
-
----
-
-### Calling Multiple Contracts
-
-A contract can call multiple other contracts. This creates multiple transactions that execute
-all in parallel. If one of them fails the rest **ARE NOT REVERTED**.
-
-<CodeTabs>
-  <Language value="js" language="js">
-    <Github fname="contract.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/contract.ts"
-      start="48" end="51" />
-    <Github fname="multiple_contracts.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/multiple_contracts.ts"
-      start="6" end="21" />
-  </Language>
-  <Language value="rust" language="rust">
-    <Github fname="multiple_contracts.rs"
-            url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-rs/src/multiple_contracts.rs"
-            start="16" end="55" />
-  </Language>
-</CodeTabs>
-
-#### Getting All Responses
-
-In this case, the callback has access to an **array of responses**, which have either the
-value returned by each call, or an error message.
-
-<CodeTabs>
-  <Language value="js" language="js">
-    <Github fname="contract.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/contract.ts"
-      start="53" end="58" />
-    <Github fname="multiple_contracts.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/multiple_contracts.ts"
-      start="24" end="41" />
-    <Github fname="utils.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/utils.ts"
-      start="3" end="20" />
-  </Language>
-  <Language value="rust" language="rust">
-    <Github fname="multiple_contracts.rs"
-            url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-rs/src/multiple_contracts.rs"
-            start="58" end="92" />
-  </Language>
-</CodeTabs>
-
----
-
-### Multiple Calls - Same Result Type
-
-This example is a particular case of the previous one ([Calling Multiple Contracts](#calling-multiple-contracts)).
-It simply showcases a different way to check the results by directly accessing the `promise_result` array.
-
-In this case, we call multiple contracts that will return the same type:
-
-<CodeTabs>
-  <Language value="js" language="js">
-    <Github fname="contract.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/contract.ts"
-      start="65" end="70" />
-    <Github fname="similar_contracts.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/similar_contracts.ts"
-      start="6" end="35" />
-  </Language>
-  <Language value="rust" language="rust">
-    <Github fname="similar_contracts.rs"
-            url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-rs/src/similar_contracts.rs"
-            start="8" end="31" />
-  </Language>
-</CodeTabs>
-
-#### Getting All Responses
-
-In this case, the callback again has access to an **array of responses**, which we can iterate checking the
-results.
-
-<CodeTabs>
-  <Language value="js" language="js">
-    <Github fname="contract.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/contract.ts"
-      start="62" end="65" />
-    <Github fname="similar_contracts.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/similar_contracts.ts"
-      start="37" end="54" />
-    <Github fname="utils.ts"
-      url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-ts/src/internal/utils.ts"
-      start="3" end="20" />
-  </Language>
-  <Language value="rust" language="rust">
-    <Github fname="similar_contracts.rs"
-            url="https://github.com/near-examples/cross-contract-calls/blob/main/contract-advanced-rs/src/similar_contracts.rs"
-            start="32" end="57" />
-  </Language>
-</CodeTabs>
-
----
-
-### Testing the Contract
-
-The contract readily includes a set of unit and sandbox testing to validate its functionality. To execute the tests, run the following commands:
-
-<Tabs groupId="code-tabs">
-  <TabItem value="js" label="🌐 JavaScript">
-
-  ```bash
-  cd contract-advanced-ts
-  yarn
-  yarn test
-  ```
-
-  </TabItem>
-  <TabItem value="rust" label="🦀 Rust">
-  
-  ```bash
-  cd contract-advanced-rs
-  cargo test
-  ```
-
-  </TabItem>
-
-</Tabs>
-
-:::tip
-The `integration tests` use a sandbox to create NEAR users and simulate interactions with the contract.
-:::
-
-<hr class="subsection" />
-
-### Deploying the Contract to the NEAR network
-
-In order to deploy the contract you will need to create a NEAR account.
-
-<Tabs groupId="cli-tabs">
-  <TabItem value="short" label="Short">
-
-  ```bash
-  # Create a new account pre-funded by a faucet
-  near create-account <accountId> --useFaucet
-  ```
-  </TabItem>
-
-  <TabItem value="full" label="Full">
-
-  ```bash
-  # Create a new account pre-funded by a faucet
-  near account create-account sponsor-by-faucet-service <my-new-dev-account>.testnet autogenerate-new-keypair save-to-keychain network-config testnet create
-  ```
-  </TabItem>
-</Tabs>
-
-Go into the directory containing the smart contract (`cd contract-advanced-ts` or `cd contract-advanced-rs`), build and deploy it:
-
-<Tabs groupId="code-tabs">
-
-  <TabItem value="js" label="🌐 JavaScript">
-
-    ```bash
-    npm run build
-    near deploy <accountId> ./build/cross_contract.wasm --initFunction new --initArgs '{"hello_account":"hello.near-example.testnet","guestbook_account":"guestbook_account.near-example.testnet","counter_account":"counter_account.near-example.testnet"}'
-    ```
-
-  </TabItem>
-  <TabItem value="rust" label="🦀 Rust">
-  
-  ```bash
-  cargo near deploy build-non-reproducible-wasm <accountId> with-init-call new json-args '{"hello_account":"hello.near-example.testnet","guestbook_account":"guestbook_account.near-example.testnet","counter_account":"counter_account.near-example.testnet"}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR' network-config testnet sign-with-keychain send
-  ```
-
-  </TabItem>
-
-</Tabs>
-
-<hr class="subsection" />
-
-### CLI: Interacting with the Contract
-
-To interact with the contract through the console, you can use the following commands:
-
-<Tabs groupId="cli-tabs">
-  <TabItem value="short" label="Short">
-  
-  ```bash
-  # Execute contracts sequentially
-  # Replace <accountId> with your account ID
-  near call <accountId> batch_actions --accountId <accountId> --gas 300000000000000   
-
-  # Execute contracts in parallel
-  # Replace <accountId> with your account ID
-  near call <accountId>  multiple_contracts --accountId <accountId> --gas 300000000000000   
-
-  # Execute multiple instances of the same contract in parallel
-  # Replace <accountId> with your account ID
-  near call <accountId> similar_contracts --accountId <accountId> --gas 300000000000000
-  ```
-  </TabItem>
-
-  <TabItem value="full" label="Full">
-  
-  ```bash
-  # Execute contracts sequentially
-  # Replace <accountId> with your account ID
-  near contract call-function as-transaction <accountId> batch_actions json-args '{}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as <accountId> network-config testnet sign-with-keychain send
-
-  # Execute contracts in parallel
-  # Replace <accountId> with your account ID
-  near contract call-function as-transaction <accountId> multiple_contracts json-args '{}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as <accountId> network-config testnet sign-with-keychain send
-
-  # Execute multiple instances of the same contract in parallel
-  # Replace <accountId> with your account ID
-  near contract call-function as-transaction <accountId> similar_contracts json-args '{}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as <accountId> network-config testnet sign-with-keychain send
-  ```
-  </TabItem>
-</Tabs>
-
-
-:::info
-If at some point you get an "Exceeded the prepaid gas" error, try to increase the gas amount used within the functions when calling other contracts
-:::
-
-:::note Versioning for this article
-
-At the time of this writing, this example works with the following versions:
-
-- near-cli: `4.0.13`
-- node: `18.19.1`
-- rustc: `1.77.0`
-
-:::
+  @private @view
+  on_multi_done(): Array<{ ok?: string; err?: string }> {
+    const out: Array<{ ok?: string; err?: string }> = [];
+    for (let i = 0; i < Near.promiseResultsCount(); i++) {
+      const r = Near.promiseResult(i);
+      out.push(r.status === 1 ? { ok: r.bufferResult.decode() } : { err: "failed" });
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
This PR migrates the “Advanced XCC” example into a focused tutorial.

- Explains when to use batching vs. parallel fan-out
- Shows how to collect the last result vs. all results in callbacks
- Covers gas/deposit budgeting, error isolation, and idempotency
- Provides minimal CLI snippets to exercise each pattern
- Includes both Rust (near-sdk-rs) and JavaScript (near-sdk-js) implementations with language tabs
- Keeps the same `id: advanced-xcc` so existing links won’t break

