### PR TITLE
docs: inline markdown content in primitives folder instead of imported components 

### DIFF
--- a/docs/primitives/dao.md
+++ b/docs/primitives/dao.md
@@ -11,34 +11,6 @@ import {FeatureList, Column, Feature} from "@site/src/components/featurelist"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import BOSGetDAOList from "@site/src/components/docs/primitives/dao/bos/get-dao-list.md"
-import BOSGetProposalList from "@site/src/components/docs/primitives/dao/bos/get-proposal-list.md"
-import BOSCreateDAO from "@site/src/components/docs/primitives/dao/bos/create-dao.md"
-import BOSCreateProposal from "@site/src/components/docs/primitives/dao/bos/create-proposal.md"
-import BOSVoteForProposal from "@site/src/components/docs/primitives/dao/bos/vote-for-proposal.md"
-
-import WebAppGetDAOList from "@site/src/components/docs/primitives/dao/web-app/get-dao-list.md"
-import WebAppGetProposalList from "@site/src/components/docs/primitives/dao/web-app/get-proposal-list.md"
-import WebAppCreateDAO from "@site/src/components/docs/primitives/dao/web-app/create-dao.md"
-import WebAppCreateProposal from "@site/src/components/docs/primitives/dao/web-app/create-proposal.md"
-import WebAppVoteForProposal from "@site/src/components/docs/primitives/dao/web-app/vote-for-proposal.md"
-
-import CLIGetDAOList from "@site/src/components/docs/primitives/dao/near-cli/get-dao-list.md"
-import CLIGetProposalList from "@site/src/components/docs/primitives/dao/near-cli/get-proposal-list.md"
-import CLICreateDAO from "@site/src/components/docs/primitives/dao/near-cli/create-dao.md"
-import CLICreateProposal from "@site/src/components/docs/primitives/dao/near-cli/create-proposal.md"
-import CLIVoteForProposal from "@site/src/components/docs/primitives/dao/near-cli/vote-for-proposal.md"
-
-import LantstoolGetDAOList from "@site/src/components/docs/primitives/dao/lantstool/get-dao-list.md"
-import LantstoolGetProposalList from "@site/src/components/docs/primitives/dao/lantstool/get-proposal-list.md"
-import LantstoolCreateDAO from "@site/src/components/docs/primitives/dao/lantstool/create-dao.md"
-import LantstoolVoteForProposal from "@site/src/components/docs/primitives/dao/lantstool/vote-for-proposal.md"
-
-
-import SmartContractCreateDAO from "@site/src/components/docs/primitives/dao/smart-contract/create-dao.md"
-import SmartContractCreateProposal from "@site/src/components/docs/primitives/dao/smart-contract/create-proposal.md"
-import SmartContractVoteForProposal from "@site/src/components/docs/primitives/dao/smart-contract/vote-for-proposal.md"
-
 import { LantstoolLabel } from "@site/src/components/lantstool/LantstoolLabel/LantstoolLabel";
 import { TryOutOnLantstool } from "@site/src/components/lantstool/TryOutOnLantstool";
 
@@ -62,16 +34,95 @@ You can create a DAO by interacting with the `sputnik-dao` contract:
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppCreateDAO />
+
+    ```js
+    import { Wallet } from './near-wallet';
+
+    const DAO_FACTORY_CONTRACT_ADDRESS = 'sputnik-dao.near';
+    const wallet = new Wallet({ createAccessKeyFor: DAO_FACTORY_CONTRACT_ADDRESS });
+
+    await wallet.callMethod({
+      method: 'create',
+      args: {
+        name: 'primitives',
+        args: btoa({
+          config: {
+            name: 'Primitives',
+            purpose: 'Building primitives on NEAR',
+            metadata: '',
+          },
+          policy: ['bob.near'],
+        }),
+      },
+      contractId: DAO_FACTORY_CONTRACT_ADDRESS,
+      gas: 300000000000000,
+      deposit: 6000000000000000000000000,
+    });
+    ```
+    :::note
+    The full list of roles and permissions you can find [here](https://github.com/near-daos/sputnik-dao-contract#roles-and-permissions).
+    :::
+
+   _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+  
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLICreateDAO />
+
+    ```bash
+    export COUNCIL='["bob.near"]'
+    export ARGS=`echo '{"config": {"name": "Primitives", "purpose": "Building primitives on NEAR", "metadata":""}, "policy": '$COUNCIL'}' | base64`
+
+    near call sputnikv2.testnet create "{\"name\": \"primitives\", \"args\": \"$ARGS\"}" --accountId bob.near --amount 6 --gas 150000000000000
+    ```
+
+    :::note
+    The full list of roles and permissions you can find [here](https://github.com/near-daos/sputnik-dao-contract#roles-and-permissions).
+    :::
+    
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolCreateDAO/>
+    <TryOutOnLantstool path="docs/2.build/5.primitives/dao/create-dao.json" />
+
+      :::note
+      You can find the complete list of [roles and permissions here](https://github.com/near-daos/sputnik-dao-contract#roles-and-permissions).
+      :::
+
   </TabItem>
   <TabItem value="📄 Contract" label="📄 Contract">
-    <SmartContractCreateDAO />
+
+    ```rust
+    // Validator interface, for cross-contract calls
+    #[ext_contract(ext_dao_factory_contract)]
+    trait ExternalDaoFactoryContract {
+      fn create(&mut self, name: AccountId, args: Base64VecU8) -> Promise;
+    }
+
+    // Implement the contract structure
+    #[near]
+    impl Contract {
+      #[payable]
+      pub fn create_dao(&mut self, name: AccountId, args: Base64VecU8) -> Promise {
+        let promise = ext_dao_factory_contract::ext(self.dao_factory_contract.clone())
+          .with_attached_deposit(env::attached_deposit())
+          .with_static_gas(Gas(30*TGAS))
+          .create(name, args);
+
+        return promise.then( // Create a promise to callback query_greeting_callback
+          Self::ext(env::current_account_id())
+          .with_static_gas(Gas(50*TGAS))
+          .external_common_callback()
+        )
+      }
+
+      #[private] // Public - but only callable by env::current_account_id()
+      pub fn external_common_callback(&self, #[callback_result] call_result: Result<(), PromiseError>) {
+        // Check if the promise succeeded
+        if call_result.is_err() {
+          log!("There was an error contacting external contract")
+        }
+      }
+    }
+    ```
   </TabItem>
 </Tabs>
 
@@ -144,13 +195,55 @@ Query the list of DAOs existing in Sputnik Dao.
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppGetDAOList />
+  
+    ```js
+    import { Wallet } from './near-wallet';
+
+    const DAO_FACTORY_CONTRACT_ADDRESS = 'sputnik-dao.near';
+    const wallet = new Wallet({ createAccessKeyFor: DAO_FACTORY_CONTRACT_ADDRESS });
+
+    await wallet.viewMethod({
+      method: 'get_dao_list',
+      args: {},
+      contractId: DAO_FACTORY_CONTRACT_ADDRESS,
+    });
+    ```
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIGetDAOList />
+
+      ```bash
+      near view sputnik-dao.near get_dao_list '{}'
+      ```
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+      ```bash
+      [
+        'ref-finance.sputnik-dao.near'
+        'gaming-dao.sputnik-dao.near',
+        ...
+      ]
+      ```
+  </p>
+  </details>  
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolGetDAOList/>
+  <TryOutOnLantstool path="docs/2.build/5.primitives/dao/dao-list.json" />
+  <details>
+  <summary>Example response</summary>
+
+  ```bash
+  [
+    'ref-finance.sputnik-dao.near'
+    'gaming-dao.sputnik-dao.near',
+    ...
+  ]
+  ```
+  </details>
   </TabItem>
 </Tabs>
 
@@ -161,14 +254,126 @@ Query the list of DAOs existing in Sputnik Dao.
 These snippets will enable you to query the proposals existing in a particular DAO.
 
 <Tabs groupId="code-tabs">
-  <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppGetProposalList />
+ <TabItem value="🌐 WebApp" label="🌐 WebApp">
+   
+    ```js
+    import { Wallet } from './near-wallet';
+
+    const DAO_CONTRACT_ADDRESS = 'nearweek-news-contribution.sputnik-dao.near';
+    const wallet = new Wallet({ createAccessKeyFor: DAO_CONTRACT_ADDRESS });
+
+    await wallet.viewMethod({
+      method: 'get_proposals',
+      args: { from_index: 9262, limit: 2 },
+      contractId: DAO_CONTRACT_ADDRESS,
+    });
+    ```
+   _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIGetProposalList />
+
+    ```bash
+    near view nearweek-news-contribution.sputnik-dao.near get_proposals '{"from_index": 9262, "limit": 2}'
+    ```
+  <details>
+    <summary>Example response</summary>
+    <p>
+
+    ```bash
+    [
+      {
+        id: 9262,
+        proposer: 'pasternag.near',
+        description: 'NEAR, a top non-EVM blockchain, has gone live on Router’s Testnet Mandara. With Router Nitro, our flagship dApp, users in the NEAR ecosystem can now transfer test tokens to and from NEAR onto other supported chains. $$$$https://twitter.com/routerprotocol/status/1727732303491961232',
+        kind: {
+          Transfer: {
+            token_id: '',
+            receiver_id: 'pasternag.near',
+            amount: '500000000000000000000000',
+            msg: null
+          }
+        },
+        status: 'Approved',
+        vote_counts: { council: [ 1, 0, 0 ] },
+        votes: { 'brzk-93444.near': 'Approve' },
+        submission_time: '1700828277659425683'
+      },
+      {
+        id: 9263,
+        proposer: 'fittedn.near',
+        description: 'How to deploy BOS component$$$$https://twitter.com/BitkubAcademy/status/1728003163318563025?t=PiN6pwS380T1N4JuQXSONA&s=19',
+        kind: {
+          Transfer: {
+            token_id: '',
+            receiver_id: 'fittedn.near',
+            amount: '500000000000000000000000',
+            msg: null
+          }
+        },
+        status: 'InProgress',
+        vote_counts: { 'Whitelisted Members': [ 1, 0, 0 ] },
+        votes: { 'trendheo.near': 'Approve' },
+        submission_time: '1700832601849419123'
+      }
+    ]
+    ```
+  </p>
+  </details>
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolGetProposalList/>
+  <TryOutOnLantstool path="docs/2.build/5.primitives/dao/query-exist-proposals.json" />
+  <details>
+  <summary>Example response</summary>
+
+  ```bash
+  [
+    {
+      "id": 9262,
+      "proposer": "pasternag.near",
+      "description": "NEAR, a top non-EVM blockchain, has gone live on Router’s Testnet Mandara. With Router Nitro, our flagship dApp, users in the NEAR ecosystem can now transfer test tokens to and from NEAR onto other supported chains. $$$$https://twitter.com/routerprotocol/status/1727732303491961232",
+      "kind": {
+        "Transfer": {
+          "token_id": "",
+          "receiver_id": "pasternag.near",
+          "amount": "500000000000000000000000",
+          "msg": null
+        }
+      },
+      "status": "Approved",
+      "vote_counts": {
+        "council": [1, 0, 0]
+      },
+      "votes": {
+        "brzk-93444.near": "Approve"
+      },
+      "submission_time": "1700828277659425683"
+    },
+    {
+      "id": 9263,
+      "proposer": "fittedn.near",
+      "description": "How to deploy BOS component$$$$https://twitter.com/BitkubAcademy/status/1728003163318563025?t=PiN6pwS380T1N4JuQXSONA&s=19",
+      "kind": {
+        "Transfer": {
+          "token_id": "",
+          "receiver_id": "fittedn.near",
+          "amount": "500000000000000000000000",
+          "msg": null
+        }
+      },
+      "status": "Expired",
+      "vote_counts": {
+        "Whitelisted Members": [2, 0, 0]
+      },
+      "votes": {
+        "trendheo.near": "Approve",
+        "vikash.near": "Approve"
+      },
+      "submission_time": "1700832601849419123"
+    }
+  ]
+  ```
+  </details>
   </TabItem>
 </Tabs>
 
@@ -180,16 +385,318 @@ Create a proposal so other users can vote in favor or against it.
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppCreateProposal />
+   
+    ```js
+    import { Wallet } from './near-wallet';
+
+    const DAO_CONTRACT_ADDRESS = 'primitives.sputnik-dao.near';
+    const wallet = new Wallet({ createAccessKeyFor: DAO_CONTRACT_ADDRESS });
+
+    await wallet.callMethod({
+      method: 'add_proposal',
+      args: {
+        proposal: {
+          description: 'My first proposal',
+          kind: {
+            Transfer: {
+              token_id: '',
+              receiver_id: 'bob.near',
+              amount: '10000000000000000000000000',
+            },
+          },
+        },
+      },
+      contractId: DAO_CONTRACT_ADDRESS,
+      gas: 300000000000000,
+      deposit: 100000000000000000000000,
+    });
+    ```
+
+   _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLICreateProposal />
+    
+   ```bash
+    near call primitives.sputnik-dao.near add_proposal '{"proposal": {"description": "My first proposal", "kind": { "Transfer": {"token_id": "", "receiver_id": "bob.near", "amount": "10000000000000000000000000"}}}}'  --deposit 0.1 --gas 300000000000000 --accountId bob.near
+  ```
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/dao/create-proposal.json" />
   </TabItem>
   <TabItem value="📄 Contract" label="📄 Contract">
-    <SmartContractCreateProposal />
+    
+  ```rust
+  // Account ID that represents a token in near-sdk v3
+  // Need to keep it around for backward compatibility
+  pub type OldAccountId = String;
+
+  // How the voting policy votes get weighted.
+  #[near(serializers = [json, borsh])
+  #[derive(Clone, PartialEq)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
+  pub enum WeightKind {
+    // Using token amounts and total delegated at the moment.
+    TokenWeight,
+    // Weight of the group role. Roles that don't have scoped group are not supported.
+    RoleWeight,
+  }
+
+  // Direct weight or ratio to total weight, used for the voting policy
+  #[near(serializers = [json, borsh])
+  #[derive(Clone)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq))]
+  #[serde(untagged)]
+  pub enum WeightOrRatio {
+    Weight(U128),
+    Ratio(u64, u64),
+  }
+
+  // Defines configuration of the vote
+  #[near(serializers = [json, borsh])
+  #[derive(Clone)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq))]
+  pub struct VotePolicy {
+    // Kind of weight to use for votes.
+    pub weight_kind: WeightKind,
+    // Minimum number required for vote to finalize.
+    // If weight kind is TokenWeight - this is minimum number of tokens required.
+    //     This allows to avoid situation where the number of staked tokens from total supply is too small.
+    // If RoleWeight - this is minimum number of votes.
+    //     This allows to avoid situation where the role is got too small but policy kept at 1/2, for example.
+    pub quorum: U128,
+    // How many votes to pass this vote.
+    pub threshold: WeightOrRatio,
+  }
+
+  #[near(serializers = [json, borsh])]
+  #[derive(Clone)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq))]
+  pub enum RoleKind {
+    // Matches everyone, who is not matched by other roles.
+    Everyone,
+    // Member greater or equal than given balance. Can use `1` as non-zero balance.
+    Member(U128),
+    // Set of accounts.
+    Group(HashSet<AccountId>),
+  }
+
+  #[near(serializers = [json, borsh])]
+  #[derive(Clone)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq))]
+  pub struct RolePermission {
+    // Name of the role to display to the user.
+    pub name: String,
+    // Kind of the role: defines which users this permissions apply.
+    pub kind: RoleKind,
+    // Set of actions on which proposals that this role is allowed to execute.
+    // <proposal_kind>:<action>
+    pub permissions: HashSet<String>,
+    // For each proposal kind, defines voting policy.
+    pub vote_policy: HashMap<String, VotePolicy>,
+  }
+
+  // Defines voting / decision making policy of this DAO
+  #[near(serializers = [json, borsh])]
+  #[derive(Clone)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq))]
+  pub struct Policy {
+    // List of roles and permissions for them in the current policy.
+    pub roles: Vec<RolePermission>,
+    // Default vote policy. Used when given proposal kind doesn't have special policy.
+    pub default_vote_policy: VotePolicy,
+    // Proposal bond.
+    pub proposal_bond: U128,
+    // Expiration period for proposals.
+    pub proposal_period: U64,
+    // Bond for claiming a bounty.
+    pub bounty_bond: U128,
+    // Period in which giving up on bounty is not punished.
+    pub bounty_forgiveness_period: U64,
+  }
+
+  // Versioned policy
+  #[near(serializers = [json, borsh])]
+  #[derive(Clone)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug, PartialEq))]
+  pub enum VersionedPolicy {
+    // Default policy with given accounts as council.
+    Default(Vec<AccountId>),
+    Current(Policy),
+  }
+
+  // Function call arguments
+  #[near(serializers = [json, borsh])]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Clone, Debug))]
+  pub struct ActionCall {
+    method_name: String,
+    args: Base64VecU8,
+    deposit: U128,
+    gas: U64,
+  }
+
+  // Bounty information.
+  #[near(serializers = [json, borsh])]
+  #[derive(Clone)]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Debug))]
+  pub struct Bounty {
+    /// Description of the bounty.
+    pub description: String,
+    /// Token the bounty will be paid out.
+    /// Can be "" for $NEAR or a valid account id.
+    pub token: OldAccountId,
+    /// Amount to be paid out.
+    pub amount: U128,
+    /// How many times this bounty can be done.
+    pub times: u32,
+    /// Max deadline from claim that can be spend on this bounty.
+    pub max_deadline: U64,
+  }
+
+  // Info about factory that deployed this contract and if auto-update is allowed
+  #[near(serializers = [json, borsh])]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Clone, Debug))]
+  pub struct FactoryInfo {
+    pub factory_id: AccountId,
+    pub auto_update: bool,
+  }
+
+  // Function call arguments
+  #[near(serializers = [json, borsh])]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Clone, Debug))]
+  pub struct PolicyParameters {
+    pub proposal_bond: Option<U128>,
+    pub proposal_period: Option<U64>,
+    pub bounty_bond: Option<U128>,
+    pub bounty_forgiveness_period: Option<U64>,
+  }
+
+  // Votes recorded in the proposal
+  #[near(serializers = [json, borsh])]
+  #[derive(Clone, Debug)]
+  pub enum Vote {
+    Approve = 0x0,
+    Reject = 0x1,
+    Remove = 0x2,
+  }
+
+  // Configuration of the DAO
+  #[near(serializers = [json, borsh])]
+  #[derive(Clone, Debug)]
+  pub struct Config {
+    // Name of the DAO.
+    pub name: String,
+    // Purpose of this DAO.
+    pub purpose: String,
+    // Generic metadata. Can be used by specific UI to store additional data.
+    // This is not used by anything in the contract.
+    pub metadata: Base64VecU8,
+  }
+
+  // Kinds of proposals, doing different action
+  #[near(serializers = [json, borsh])]
+  #[cfg_attr(not(target_arch = "wasm32"), derive(Clone, Debug))]
+  pub enum ProposalKind {
+    // Change the DAO config.
+    ChangeConfig { config: Config },
+    // Change the full policy.
+    ChangePolicy { policy: VersionedPolicy },
+    // Add member to given role in the policy. This is short cut to updating the whole policy.
+    AddMemberToRole { member_id: AccountId, role: String },
+    // Remove member to given role in the policy. This is short cut to updating the whole policy.
+    RemoveMemberFromRole { member_id: AccountId, role: String },
+    // Calls `receiver_id` with list of method names in a single promise.
+    // Allows this contract to execute any arbitrary set of actions in other contracts.
+    FunctionCall {
+        receiver_id: AccountId,
+        actions: Vec<ActionCall>,
+    },
+    // Upgrade this contract with given hash from blob store.
+    UpgradeSelf { hash: Base58CryptoHash },
+    // Upgrade another contract, by calling method with the code from given hash from blob store.
+    UpgradeRemote {
+        receiver_id: AccountId,
+        method_name: String,
+        hash: Base58CryptoHash,
+    },
+    // Transfers given amount of `token_id` from this DAO to `receiver_id`.
+    // If `msg` is not None, calls `ft_transfer_call` with given `msg`. Fails if this base token.
+    // For `ft_transfer` and `ft_transfer_call` `memo` is the `description` of the proposal.
+    Transfer {
+        // Can be "" for $NEAR or a valid account id.
+        token_id: OldAccountId,
+        receiver_id: AccountId,
+        amount: U128,
+        msg: Option<String>,
+    },
+    // Sets staking contract. Can only be proposed if staking contract is not set yet.
+    SetStakingContract { staking_id: AccountId },
+    // Add new bounty.
+    AddBounty { bounty: Bounty },
+    // Indicates that given bounty is done by given user.
+    BountyDone {
+        bounty_id: u64,
+        receiver_id: AccountId,
+    },
+    // Just a signaling vote, with no execution.
+    Vote,
+    // Change information about factory and auto update.
+    FactoryInfoUpdate { factory_info: FactoryInfo },
+    // Add new role to the policy. If the role already exists, update it. This is short cut to updating the whole policy.
+    ChangePolicyAddOrUpdateRole { role: RolePermission },
+    // Remove role from the policy. This is short cut to updating the whole policy.
+    ChangePolicyRemoveRole { role: String },
+    // Update the default vote policy from the policy. This is short cut to updating the whole policy.
+    ChangePolicyUpdateDefaultVotePolicy { vote_policy: VotePolicy },
+    // Update the parameters from the policy. This is short cut to updating the whole policy.
+    ChangePolicyUpdateParameters { parameters: PolicyParameters },
+  }
+
+  #[near(serializers = [json])]
+  pub struct ProposalInput {
+    /// Description of this proposal.
+    pub description: String,
+    /// Kind of proposal with relevant information.
+    pub kind: ProposalKind,
+  }
+
+  // Validator interface, for cross-contract calls
+  #[ext_contract(ext_dao_contract)]
+  trait ExternalDaoContract {
+    fn add_proposal(&mut self, proposal: ProposalInput) -> Promise;
+  }
+
+  // Implement the contract structure
+  #[near]
+  impl Contract {
+    #[payable]
+    pub fn create_proposal(&mut self, proposal: ProposalInput) -> Promise {
+      let promise = ext_dao_contract::ext(self.dao_contract.clone())
+        .with_attached_deposit(env::attached_deposit())
+        .with_static_gas(Gas(5*TGAS))
+        .add_proposal(proposal);
+
+      return promise.then( // Create a promise to callback query_greeting_callback
+        Self::ext(env::current_account_id())
+        .with_static_gas(Gas(50*TGAS))
+        .external_proposal_callback()
+      )
+    }
+
+    #[private] // Public - but only callable by env::current_account_id()
+    pub fn external_proposal_callback(&self, #[callback_result] call_result: Result<u64, PromiseError>) -> Option<u64> {
+      if call_result.is_err() {
+        log!("There was an error contacting external contract");
+        return None;
+      }
+
+      // Return the proposal id
+      let id = call_result.unwrap();
+      return Some(id);
+    }
+  }
+  ```
+     
   </TabItem>
 </Tabs>
 
@@ -205,17 +712,101 @@ These snippet will enable your users to cast a vote for proposal of a particular
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppVoteForProposal />
+
+  ```js
+  import { Wallet } from './near-wallet';
+
+  const DAO_CONTRACT_ADDRESS = 'primitives.sputnik-dao.near';
+  const wallet = new Wallet({ createAccessKeyFor: DAO_CONTRACT_ADDRESS });
+
+  await wallet.callMethod({
+    method: 'act_proposal',
+    args: { id: 0, action: 'VoteApprove' },
+    contractId: DAO_CONTRACT_ADDRESS,
+    gas: 300000000000000,
+  });
+  ```
+
+  :::note
+  Available vote options: `VoteApprove`, `VoteReject`, `VoteRemove`.
+  :::
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIVoteForProposal />
+    
+  ```bash
+  near call primitives.sputnik-dao.near act_proposal '{"id": 0, "action": "VoteApprove"}' --gas 300000000000000 --accountId bob.near
+  ```
+  :::note
+  Available vote options: `VoteApprove`, `VoteReject`, `VoteRemove`.
+  :::
+
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolVoteForProposal/>
+    <TryOutOnLantstool path="docs/2.build/5.primitives/dao/vote-proposal.json" />
+
+    :::note
+    Available vote options: `VoteApprove`, `VoteReject`, `VoteRemove`.
+    :::
   </TabItem>
   <TabItem value="📄 Contract" label="📄 Contract">
-    <SmartContractVoteForProposal />
-  </TabItem>
+    
+  ```rust
+// Set of possible action to take
+#[near(serializers = [json, borsh])]
+#[derive(Debug)]
+pub enum Action {
+  // Action to add proposal. Used internally.
+  AddProposal,
+  // Action to remove given proposal. Used for immediate deletion in special cases.
+  RemoveProposal,
+  // Vote to approve given proposal or bounty.
+  VoteApprove,
+  // Vote to reject given proposal or bounty.
+  VoteReject,
+  // Vote to remove given proposal or bounty (because it's spam).
+  VoteRemove,
+  // Finalize proposal, called when it's expired to return the funds
+  // (or in the future can be used for early proposal closure).
+  Finalize,
+  // Move a proposal to the hub to shift into another DAO.
+  MoveToHub,
+}
+
+// Validator interface, for cross-contract calls
+#[ext_contract(ext_dao_contract)]
+trait ExternalDaoContract {
+  fn act_proposal(&mut self, id: u64, action: Action, memo: Option<String>) -> Promise;
+}
+
+// Implement the contract structure
+#[near]
+impl Contract {
+  #[payable]
+  pub fn act_proposal(&mut self, id: u64, action: Action, memo: Option<String>) -> Promise {
+    let promise = ext_dao_contract::ext(self.dao_contract.clone())
+      .with_attached_deposit(env::attached_deposit())
+      .with_static_gas(Gas(10*TGAS))
+      .act_proposal(id, action, memo);
+
+    return promise.then( // Create a promise to callback query_greeting_callback
+      Self::ext(env::current_account_id())
+      .external_common_callback()
+    )
+  }
+
+  #[private] // Public - but only callable by env::current_account_id()
+  pub fn external_common_callback(&self, #[callback_result] call_result: Result<(), PromiseError>) {
+    // Check if the promise succeeded
+    if call_result.is_err() {
+      log!("There was an error contacting external contract")
+    }
+  }
+}
+```
+</TabItem>
 </Tabs>
 
 ---

--- a/docs/primitives/dex.md
+++ b/docs/primitives/dex.md
@@ -10,29 +10,6 @@ import {FeatureList, Column, Feature} from "@site/src/components/featurelist"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import BOSGetPrice from "@site/src/components/docs/primitives/dex/bos/get-price.md"
-import BOSSwap from "@site/src/components/docs/primitives/dex/bos/swap.md"
-import BOSGetPools from "@site/src/components/docs/primitives/dex/bos/get-pools.md"
-import BOSGetDepositBalances from "@site/src/components/docs/primitives/dex/bos/get-deposit-balances.md"
-
-import WebAppGetPrice from "@site/src/components/docs/primitives/dex/web-app/get-price.md"
-import WebAppSwap from "@site/src/components/docs/primitives/dex/web-app/swap.md"
-import WebAppGetPools from "@site/src/components/docs/primitives/dex/web-app/get-pools.md"
-import WebAppGetDepositBalances from "@site/src/components/docs/primitives/dex/web-app/get-deposit-balances.md"
-
-import CLISwap from "@site/src/components/docs/primitives/dex/near-cli/swap.md"
-import CLIGetPools from "@site/src/components/docs/primitives/dex/near-cli/get-pools.md"
-import CLIGetDepositBalances from "@site/src/components/docs/primitives/dex/near-cli/get-deposit-balances.md"
-
-import LantstoolSwap from "@site/src/components/docs/primitives/dex/lantstool/swap.md"
-import LantstoolGetWithelistedTokens from "@site/src/components/docs/primitives/dex/lantstool/get-whitelisted-tokens.md"
-import LantstoolGetDepositBalances from "@site/src/components/docs/primitives/dex/lantstool/get-deposit-balances.md"
-import LantstoolGetPools from "@site/src/components/docs/primitives/dex/lantstool/get-pools.md"
-
-import SmartContractSwap from "@site/src/components/docs/primitives/dex/smart-contract/swap.md"
-import SmartContractGetPools from "@site/src/components/docs/primitives/dex/smart-contract/get-pools.md"
-import SmartContractGetDepositBalances from "@site/src/components/docs/primitives/dex/smart-contract/get-deposit-balances.md"
-
 import { LantstoolLabel } from "@site/src/components/lantstool/LantstoolLabel/LantstoolLabel";
 import { TryOutOnLantstool } from "@site/src/components/lantstool/TryOutOnLantstool";
 
@@ -59,7 +36,34 @@ One can query the exchange rate of a token pair by calling the `get-token-price`
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppGetPrice />
+
+    ```js
+    const tokenContract = 'token.v2.ref-finance.near';
+    const tokenPriceResult = await fetch(
+      `https://indexer.ref.finance/get-token-price?token_id=${tokenContract}`,
+    );
+    const tokenPriceValue = await tokenPriceResult.json();
+    ```
+
+    _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
+  <details>
+  <summary>Example response</summary>
+    <p>
+
+    ```json
+    {
+      "token_contract_id": "token.v2.ref-finance.near",
+      "price": "0.08153090"
+    }
+    ```
+  </p>
+  </details>
+
+    :::tip
+    Ref Finance has a method to [get all token prices at once](https://indexer.ref.finance/list-token-price).
+    :::
+
   </TabItem>
 </Tabs>
 
@@ -92,8 +96,24 @@ near view v2.ref-finance.near get_whitelisted_tokens
 </details>
 
   </TabItem>
-  <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolGetWithelistedTokens/>
+  <TabItem value="Lantstool" label={<LantstoolLabel />}> 
+   <TryOutOnLantstool path="docs/2.build/5.primitives/dex/whitelist-tokens.json" />
+  <details>
+  <summary> Examples Response </summary>
+
+    ```bash
+      'wrap.near',
+      'usdt.tether-token.near',
+      'berryclub.ek.near',
+      'farm.berryclub.ek.near',
+      'token.v2.ref-finance.near',
+      'token.paras.near',
+      'marmaj.tkn.near',
+      'meta-pool.near',
+      ...
+    ```
+
+  </details>
   </TabItem>
 </Tabs>
 
@@ -154,16 +174,109 @@ Query your deposit balances by calling the `get_deposits` method:
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppGetDepositBalances />
+    
+  ```js
+  const AMM_CONTRACT_ADDRESS = 'v2.ref-finance.near';
+  const wallet = new Wallet({ createAccessKeyFor: AMM_CONTRACT_ADDRESS });
+
+  await wallet.viewMethod({
+    method: 'get_deposits',
+    args: {
+      account_id: 'bob.near',
+    },
+    contractId: AMM_CONTRACT_ADDRESS,
+  });
+  ```
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```json
+  {
+    "token.v2.ref-finance.near": "0",
+    "wrap.near": "0"
+  }
+  ```
+  </p>
+  </details>
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIGetDepositBalances />
+
+  ```bash
+  near view v2.ref-finance.near get_deposits '{"account_id": "bob.near"}'
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```bash
+  {
+    'token.v2.ref-finance.near': '0',
+    'wrap.near': "0"
+  }
+  ```
+  </p>
+  </details>
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolGetDepositBalances/>
+
+  <TryOutOnLantstool path="docs/2.build/5.primitives/dex/deposit-balance.json" />
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```bash
+  {
+    'token.v2.ref-finance.near': '0',
+    'wrap.near': "0"
+  }
+  ```
+
+  </p>
+  </details>
   </TabItem>
   <TabItem value="📄 Contract" label="📄 Contract">
-    <SmartContractGetDepositBalances />
+ 
+      ```rust
+  // Validator interface, for cross-contract calls
+  #[ext_contract(ext_amm_contract)]
+  trait ExternalAmmContract {
+    fn get_deposits(&self, account_id: AccountId) -> Promise;
+  }
+
+  // Implement the contract structure
+  #[near]
+  impl Contract {
+    #[private] // Public - but only callable by env::current_account_id()
+    pub fn external_get_deposits_callback(&self, #[callback_result] call_result: Result<HashMap<AccountId, U128>, PromiseError>) -> Option<HashMap<AccountId, U128>> {
+      // Check if the promise succeeded
+      if call_result.is_err() {
+        log!("There was an error contacting external contract");
+        return None;
+      }
+
+      // Return the pools data
+      let deposits_data = call_result.unwrap();
+      return Some(deposits_data);
+    }
+
+    pub fn get_contract_deposits(&self) -> Promise {
+      let promise = ext_amm_contract::ext(self.amm_contract.clone())
+        .get_deposits(env::current_account_id());
+
+      return promise.then( // Create a promise to callback query_greeting_callback
+        Self::ext(env::current_account_id())
+        .external_get_deposits_callback()
+      )
+    }
+  }
+  ```
   </TabItem>
 </Tabs>
 
@@ -175,16 +288,176 @@ DEXs work by having multiple pools of token pairs (e.g. NEAR-USDC) that users ca
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppGetPools />
+
+  ```js
+  const AMM_CONTRACT_ADDRESS = 'v2.ref-finance.near';
+  const wallet = new Wallet({ createAccessKeyFor: AMM_CONTRACT_ADDRESS });
+
+  await wallet.viewMethod({
+    method: 'get_pools',
+    args: {
+      from_index: 0,
+      limit: 1000,
+    },
+    contractId: AMM_CONTRACT_ADDRESS,
+  });
+  ```
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```js
+  [
+    {
+      pool_kind: 'SIMPLE_POOL',
+      token_account_ids: ['token.skyward.near', 'wrap.near'],
+      amounts: ['51865812079751349630100', '6254162663147994789053210138'],
+      total_fee: 30,
+      shares_total_supply: '1305338644973934698612124055',
+      amp: 0,
+    },
+    {
+      pool_kind: 'SIMPLE_POOL',
+      token_account_ids: [
+        'c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.factory.bridge.near',
+        'wrap.near',
+      ],
+      amounts: ['783621938569399817', '1100232280852443291118200599'],
+      total_fee: 30,
+      shares_total_supply: '33923015415693335344747628',
+      amp: 0,
+    },
+  ];
+  ```
+  </p>
+  </details>  
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIGetPools />
+  
+      ```bash
+      near view v2.ref-finance.near get_pools '{"from_index": 0, "limit": 1000}'
+      ```
+  <details>
+  <summary>Example response</summary>
+  <p>
+  
+  ```bash
+  [
+    {
+      pool_kind: 'SIMPLE_POOL',
+      token_account_ids: [ 'token.skyward.near', 'wrap.near' ],
+      amounts: [ '51865812079751349630100', '6254162663147994789053210138' ],
+      total_fee: 30,
+      shares_total_supply: '1305338644973934698612124055',
+      amp: 0
+    },
+    {
+      pool_kind: 'SIMPLE_POOL',
+      token_account_ids: [
+        'c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.factory.bridge.near',
+        'wrap.near'
+      ],
+      amounts: [ '783621938569399817', '1100232280852443291118200599' ],
+      total_fee: 30,
+      shares_total_supply: '33923015415693335344747628',
+      amp: 0
+    }
+  ]
+  ```
+  </p>
+  </details>
+
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolGetPools/>
+
+  <TryOutOnLantstool path="docs/2.build/5.primitives/dex/query-pools.json" />
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```bash
+  [
+    {
+      pool_kind: 'SIMPLE_POOL',
+      token_account_ids: [ 'token.skyward.near', 'wrap.near' ],
+      amounts: [ '51865812079751349630100', '6254162663147994789053210138' ],
+      total_fee: 30,
+      shares_total_supply: '1305338644973934698612124055',
+      amp: 0
+    },
+    {
+      pool_kind: 'SIMPLE_POOL',
+      token_account_ids: [
+        'c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.factory.bridge.near',
+        'wrap.near'
+      ],
+      amounts: [ '783621938569399817', '1100232280852443291118200599' ],
+      total_fee: 30,
+      shares_total_supply: '33923015415693335344747628',
+      amp: 0
+    }
+  ]
+  ```
+  </p>
+  </details>
+
   </TabItem>
   <TabItem value="📄 Contract" label="📄 Contract">
-    <SmartContractGetPools />
+
+  ```rust
+  #[near(serializers = [json])]
+  pub struct PoolInfo {
+    /// Pool kind.
+    pub pool_kind: String,
+    /// List of tokens in the pool.
+    pub token_account_ids: Vec<AccountId>,
+    /// How much NEAR this contract has.
+    pub amounts: Vec<U128>,
+    /// Fee charged for swap.
+    pub total_fee: u32,
+    /// Total number of shares.
+    pub shares_total_supply: U128,
+    pub amp: u64,
+  }
+
+  // Validator interface, for cross-contract calls
+  #[ext_contract(ext_amm_contract)]
+  trait ExternalAmmContract {
+    fn get_pools(&self, from_index: u64, limit: u64) -> Promise;
+  }
+
+  // Implement the contract structure
+  #[near]
+  impl Contract {
+    #[private] // Public - but only callable by env::current_account_id()
+    pub fn external_get_pools_callback(&self, #[callback_result] call_result: Result<Vec<PoolInfo>, PromiseError>) -> Option<Vec<PoolInfo>> {
+      // Check if the promise succeeded
+      if call_result.is_err() {
+        log!("There was an error contacting external contract");
+        return None;
+      }
+
+      // Return the pools data
+      let pools_data = call_result.unwrap();
+      return Some(pools_data);
+    }
+
+    pub fn get_amm_pools(&self, from_index: u64, limit: u64) -> Promise {
+      let promise = ext_amm_contract::ext(self.amm_contract.clone())
+        .get_pools(from_index, limit);
+
+      return promise.then( // Create a promise to callback query_greeting_callback
+        Self::ext(env::current_account_id())
+        .external_get_pools_callback()
+      )
+    }
+  }
+  ```
   </TabItem>
 </Tabs>
 
@@ -195,16 +468,137 @@ In order to swap a token for another, you need to [have funds](#deposit-funds), 
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppSwap />
+
+    ```js
+    import { Wallet } from './near-wallet';
+
+    const AMM_CONTRACT_ADDRESS = 'v2.ref-finance.near';
+    const wallet = new Wallet({ createAccessKeyFor: AMM_CONTRACT_ADDRESS });
+
+    await wallet.callMethod({
+      method: 'swap',
+      args: {
+        actions: [
+          {
+            pool_id: 79,
+            token_in: 'token.v2.ref-finance.near',
+            token_out: 'wrap.near',
+            amount_in: '100000000000000000',
+            min_amount_out: '1',
+          },
+        ],
+      },
+      contractId: AMM_CONTRACT_ADDRESS,
+      gas: 300000000000000,
+      deposit: 1,
+    });
+    ```
+
+    _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
+  <details>
+  <summary>Example response</summary>
+
+    ```json
+    "5019606679394603179450"
+    ```
+  </details>
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLISwap />
+   
+  ```bash
+  near call v2.ref-finance.near swap "{\"actions\": [{\"pool_id\": 79, \"token_in\": \"token.v2.ref-finance.near\", \"amount_in\": \"100000000000000000\", \"token_out\": \"wrap.near\", \"min_amount_out\": \"1\"}]}" --gas 300000000000000 --depositYocto 1
+  --accountId bob.near
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```bash
+  '5019606679394603179450'
+  ```
+  </p>
+  </details>
+
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
-    <LantstoolSwap/>
+  <TryOutOnLantstool path="docs/2.build/5.primitives/dex/swap-tokens.json" />
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```bash
+  '5019606679394603179450'
+  ```
+  </p>
+  </details>
   </TabItem>
   <TabItem value="📄 Contract" label="📄 Contract">
-    <SmartContractSwap />
+
+  ```rust
+  #[near(serializers = [json])]
+  pub struct SwapAction {
+      /// Pool which should be used for swapping.
+      pub pool_id: u64,
+      /// Token to swap from.
+      pub token_in: AccountId,
+      /// Amount to exchange.
+      /// If amount_in is None, it will take amount_out from previous step.
+      /// Will fail if amount_in is None on the first step.
+      pub amount_in: Option<U128>,
+      /// Token to swap into.
+      pub token_out: AccountId,
+      /// Required minimum amount of token_out.
+      pub min_amount_out: U128,
+  }
+
+  // Validator interface, for cross-contract calls
+  #[ext_contract(ext_amm_contract)]
+  trait ExternalAmmContract {
+    fn swap(&self, actions: Vec<SwapAction>) -> Promise;
+  }
+
+  // Implement the contract structure
+  #[near]
+  impl Contract {
+    #[private] // Public - but only callable by env::current_account_id()
+    pub fn external_call_callback(&self, #[callback_result] call_result: Result<String, PromiseError>) {
+      // Check if the promise succeeded
+      if call_result.is_err() {
+        log!("There was an error contacting external contract");
+      }
+    }
+
+    #[payable]
+    pub fn swap_tokens(&mut self, pool_id: u64, token_in: AccountId, token_out: AccountId, amount_in: U128, min_amount_out: U128) -> Promise {
+      assert_eq!(env::attached_deposit(), 1, "Requires attached deposit of exactly 1 yoctoNEAR");
+
+      let swap_action = SwapAction {
+        pool_id,
+        token_in,
+        token_out,
+        amount_in: Some(amount_in),
+        min_amount_out
+      };
+
+      let mut actions = Vec::new();
+      actions.push(swap_action);
+
+      let promise = ext_amm_contract::ext(self.amm_contract.clone())
+        .with_static_gas(Gas(150*TGAS))
+        .with_attached_deposit(YOCTO_NEAR)
+        .swap(actions);
+
+      return promise.then( // Create a promise to callback query_greeting_callback
+        Self::ext(env::current_account_id())
+        .with_static_gas(Gas(100*TGAS))
+        .external_call_callback()
+      )
+    }
+  }
+  ```
   </TabItem>
 </Tabs>
 

--- a/docs/primitives/ft.md
+++ b/docs/primitives/ft.md
@@ -10,31 +10,6 @@ import {FeatureList, Column, Feature} from "@site/src/components/featurelist"
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import BOSGetMetadata from "@site/src/components/docs/primitives/ft/bos/get-metadata.md"
-import BOSCheckBalance from "@site/src/components/docs/primitives/ft/bos/check-balance.md"
-import BOSSendToken from "@site/src/components/docs/primitives/ft/bos/send.md"
-import BOSRegister from "@site/src/components/docs/primitives/ft/bos/register.md"
-import BOSAttachTokenToCall from "@site/src/components/docs/primitives/ft/bos/attach-to-call.md"
-import BOSCreateToken from "@site/src/components/docs/primitives/ft/bos/create.md"
-
-import WebAppGetMetadata from "@site/src/components/docs/primitives/ft/web-app/get-metadata.md"
-import WebAppCheckBalance from "@site/src/components/docs/primitives/ft/web-app/check-balance.md"
-import WebAppSendToken from "@site/src/components/docs/primitives/ft/web-app/send.md"
-import WebAppRegister from "@site/src/components/docs/primitives/ft/web-app/register.md"
-import WebAppAttachTokenToCall from "@site/src/components/docs/primitives/ft/web-app/attach-to-call.md"
-import WebAppCreateToken from "@site/src/components/docs/primitives/ft/web-app/create.md"
-
-import CLIGetMetadata from "@site/src/components/docs/primitives/ft/near-cli/get-metadata.md"
-import CLICheckBalance from "@site/src/components/docs/primitives/ft/near-cli/check-balance.md"
-import CLISendToken from "@site/src/components/docs/primitives/ft/near-cli/send.md"
-import CLIRegister from "@site/src/components/docs/primitives/ft/near-cli/register.md"
-import CLIAttachTokenToCall from "@site/src/components/docs/primitives/ft/near-cli/attach-to-call.md"
-import CLICreateToken from "@site/src/components/docs/primitives/ft/near-cli/create.md"
-import CLICreateTokenManually from "@site/src/components/docs/primitives/ft/near-cli/create-manually.md"
-
-import SmartContractSendToken from "@site/src/components/docs/primitives/ft/smart-contract/send.md"
-import SmartContractAttachTokenToCall from "@site/src/components/docs/primitives/ft/smart-contract/attach-to-call.md"
-
 import { LantstoolLabel } from "@site/src/components/lantstool/LantstoolLabel/LantstoolLabel";
 import { TryOutOnLantstool } from "@site/src/components/lantstool/TryOutOnLantstool";
 
@@ -73,10 +48,44 @@ Here is how to directly interact with the factory contract through your applicat
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppCreateToken />
+
+    ```js
+    import { Wallet } from './near-wallet';
+
+    const wallet = new Wallet({});
+
+    const args = {
+      args: {
+        owner_id: 'bob.near',
+        total_supply: '1000000000',
+        metadata: {
+          spec: 'ft-1.0.0',
+          name: 'Test Token',
+          symbol: 'test',
+          icon: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+          decimals: 18,
+        },
+      },
+      account_id: 'bob.near',
+    };
+
+    await wallet.callMethod({
+      method: 'create_token',
+      args,
+      contractId: 'tkn.primitives.near',
+      gas: 300000000000000,
+      deposit: '2234830000000000000000000',
+    });
+    ```
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLICreateToken />
+
+    ```bash
+    near call tkn.primitives.near create_token '{"args":{"owner_id": "bob.near","total_supply": "1000000000","metadata":{"spec": "ft-1.0.0","name": "Test Token","symbol": "TTTEST","icon": "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7","decimals": 18}},"account_id": "bob.near"}' --gas 300000000000000 --depositYocto 2234830000000000000000000 --accountId bob.near
+    ```
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/ft/create-ft-via-factory.json" />
@@ -99,7 +108,25 @@ To initialize a FT contract you will need to deploy it and then call the `new` m
 
 <Tabs groupId="code-tabs">
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLICreateTokenManually />
+
+    ```bash
+    cargo near deploy build-non-reproducible-wasm <account-id> \
+      with-init-call new \
+      json-args '{
+        "owner_id": "<owner-account>",
+        "total_supply": "1000000000000000",
+        "metadata": {
+          "spec": "ft-1.0.0",
+          "name": "Example Token Name",
+          "symbol": "EXLT",
+          "decimals": 8
+        }
+      }' \
+      prepaid-gas '100.0 Tgas' \
+      attached-deposit '0 NEAR' \
+      network-config testnet \
+      sign-with-keychain send
+    ```
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/ft/create-ft-manually.json" />
@@ -126,7 +153,6 @@ You can deploy a new Fungible Token using our global FT contract - a pre-deploye
       network-config testnet \
       sign-with-keychain send
     ```
-
   </TabItem>
   <TabItem value="hash" label="By Hash">
 
@@ -154,10 +180,98 @@ You can query the FT's metadata by calling the `ft_metadata`.
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppGetMetadata />
+
+  ```js
+  import { Wallet } from './near-wallet';
+
+  const TOKEN_CONTRACT_ADDRESS = 'token.v2.ref-finance.near';
+  const wallet = new Wallet({ createAccessKeyFor: TOKEN_CONTRACT_ADDRESS });
+
+  await wallet.viewMethod({
+    method: 'ft_metadata',
+    args: {},
+    contractId: TOKEN_CONTRACT_ADDRESS,
+  });
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```json
+  {
+    "spec": "ft-1.0.0",
+    "name": "Ref Finance Token",
+    "symbol": "REF",
+    "icon": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='16 24 248 248' style='background: %23000'%3E%3Cpath d='M164,164v52h52Zm-45-45,20.4,20.4,20.6-20.6V81H119Zm0,18.39V216h41V137.19l-20.6,20.6ZM166.5,81H164v33.81l26.16-26.17A40.29,40.29,0,0,0,166.5,81ZM72,153.19V216h43V133.4l-11.6-11.61Zm0-18.38,31.4-31.4L115,115V81H72ZM207,121.5h0a40.29,40.29,0,0,0-7.64-23.66L164,133.19V162h2.5A40.5,40.5,0,0,0,207,121.5Z' fill='%23fff'/%3E%3Cpath d='M189 72l27 27V72h-27z' fill='%2300c08b'/%3E%3C/svg%3E%0A",
+    "reference": null,
+    "reference_hash": null,
+    "decimals": 18
+  }
+  ```
+
+  </p>
+  </details>
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+  ```js
+  import { Wallet } from './near-wallet';
+
+  const TOKEN_CONTRACT_ADDRESS = 'token.v2.ref-finance.near';
+  const wallet = new Wallet({ createAccessKeyFor: TOKEN_CONTRACT_ADDRESS });
+
+  await wallet.viewMethod({
+    method: 'ft_metadata',
+    args: {},
+    contractId: TOKEN_CONTRACT_ADDRESS,
+  });
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```json
+  {
+    "spec": "ft-1.0.0",
+    "name": "Ref Finance Token",
+    "symbol": "REF",
+    "icon": "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='16 24 248 248' style='background: %23000'%3E%3Cpath d='M164,164v52h52Zm-45-45,20.4,20.4,20.6-20.6V81H119Zm0,18.39V216h41V137.19l-20.6,20.6ZM166.5,81H164v33.81l26.16-26.17A40.29,40.29,0,0,0,166.5,81ZM72,153.19V216h43V133.4l-11.6-11.61Zm0-18.38,31.4-31.4L115,115V81H72ZM207,121.5h0a40.29,40.29,0,0,0-7.64-23.66L164,133.19V162h2.5A40.5,40.5,0,0,0,207,121.5Z' fill='%23fff'/%3E%3Cpath d='M189 72l27 27V72h-27z' fill='%2300c08b'/%3E%3C/svg%3E%0A",
+    "reference": null,
+    "reference_hash": null,
+    "decimals": 18
+  }
+  ```
+
+  </p>
+  </details>
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIGetMetadata />
+
+    ```bash
+    near view token.v2.ref-finance.near ft_metadata
+    ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+    ```bash
+    {
+      spec: "ft-1.0.0",
+      name: "Ref Finance Token",
+      symbol: "REF",
+      icon: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='16 24 248 248' style='background: %23000'%3E%3Cpath d='M164,164v52h52Zm-45-45,20.4,20.4,20.6-20.6V81H119Zm0,18.39V216h41V137.19l-20.6,20.6ZM166.5,81H164v33.81l26.16-26.17A40.29,40.29,0,0,0,166.5,81ZM72,153.19V216h43V133.4l-11.6-11.61Zm0-18.38,31.4-31.4L115,115V81H72ZM207,121.5h0a40.29,40.29,0,0,0-7.64-23.66L164,133.19V162h2.5A40.5,40.5,0,0,0,207,121.5Z' fill='%23fff'/%3E%3Cpath d='M189 72l27 27V72h-27z' fill='%2300c08b'/%3E%3C/svg%3E%0A",
+      reference: null,
+      reference_hash: null,
+      decimals: 18
+    }
+    ```
+  </p>
+  </details>
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/ft/query-ft-metadata.json" />
@@ -171,10 +285,55 @@ To know how many coins a user has you will need to query the method `ft_balance_
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppCheckBalance />
+
+  :::info
+  Remember about fungible token precision. You may need this value to show a response of balance requests in an understandable-to-user way in your app. How to get precision value (decimals) you may find [here](#querying-metadata).
+  :::
+
+  ```js
+  import { Wallet } from './near-wallet';
+
+  const TOKEN_CONTRACT_ADDRESS = 'token.v2.ref-finance.near';
+  const wallet = new Wallet({ createAccessKeyFor: TOKEN_CONTRACT_ADDRESS });
+
+  await wallet.viewMethod({
+    method: 'ft_balance_of',
+    args: {
+      account_id: 'bob.near',
+    },
+    contractId: TOKEN_CONTRACT_ADDRESS,
+  });
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```json
+  "3479615037675962643842"
+  ```
+
+  </p>
+  </details>
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLICheckBalance />
+
+  ```bash
+  near view token.v2.ref-finance.near ft_balance_of '{"account_id": "bob.near"}'
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```bash
+  '376224322825327177426'
+  ```
+  </p>
+  </details>
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/ft/check-ft-balance.json" />
@@ -190,10 +349,26 @@ By calling this `storage_deposit` the user can register themselves or **register
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppRegister />
+
+  ```js
+  await wallet.callMethod({
+    method: 'storage_deposit',
+    args: {
+      account_id: 'alice.near',
+    },
+    contractId: TOKEN_CONTRACT_ADDRESS,
+    deposit: 1250000000000000000000,
+  });
+  ```
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIRegister />
+
+  ```bash
+  near call token.v2.ref-finance.near storage_deposit '{"account_id": "alice.near"}' --depositYocto 1250000000000000000000 --accountId bob.near
+  ```
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/ft/register-user.json" />
@@ -215,16 +390,67 @@ To send FT to another account you will use the `ft_transfer` method, indicating 
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppSendToken />
+    
+  ```js
+  import { Wallet } from './near-wallet';
+
+  const TOKEN_CONTRACT_ADDRESS = 'token.v2.ref-finance.near';
+  const wallet = new Wallet({ createAccessKeyFor: TOKEN_CONTRACT_ADDRESS });
+
+  await wallet.callMethod({
+    method: 'ft_transfer',
+    args: {
+      receiver_id: 'alice.near',
+      amount: '100000000000000000',
+    },
+    contractId: TOKEN_CONTRACT_ADDRESS,
+    deposit: 1,
+  });
+  ```
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLISendToken />
+
+    ```bash
+    near call token.v2.ref-finance.near ft_transfer '{"receiver_id": "alice.near", "amount": "100000000000000000"}' --depositYocto 1 --accountId bob.near
+    ```
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/ft/transfer-tokens.json" />
   </TabItem>
   <TabItem value="📄 Contract"  label="📄 Contract"  default>
-    <SmartContractSendToken />
+    
+  ```rust
+  #[near]
+  impl Contract {
+    #[payable]
+    pub fn send_tokens(&mut self, receiver_id: AccountId, amount: U128) -> Promise {
+      assert_eq!(env::attached_deposit(), 1, "Requires attached deposit of exactly 1 yoctoNEAR");
+
+      let promise = ext(self.ft_contract.clone())
+        .with_attached_deposit(YOCTO_NEAR)
+        .ft_transfer(receiver_id, amount, None);
+
+      return promise.then( // Create a promise to callback query_greeting_callback
+        Self::ext(env::current_account_id())
+        .with_static_gas(Gas(30*TGAS))
+        .external_call_callback()
+      )
+    }
+
+    #[private] // Public - but only callable by env::current_account_id()
+    pub fn external_call_callback(&self, #[callback_result] call_result: Result<(), PromiseError>) {
+      // Check if the promise succeeded
+      if call_result.is_err() {
+        log!("There was an error contacting external contract");
+      }
+    }
+  }
+  ```
+
+  _This snippet assumes that the contract is already holding some FTs and that you want to send them to another account._
   </TabItem>
 </Tabs>
 
@@ -237,16 +463,80 @@ Let's assume that you need to deposit FTs on Ref Finance.
 
 <Tabs groupId="code-tabs">
   <TabItem value="🌐 WebApp" label="🌐 WebApp">
-    <WebAppAttachTokenToCall />
+
+  ```js
+  import { Wallet } from './near-wallet';
+
+  const TOKEN_CONTRACT_ADDRESS = 'token.v2.ref-finance.near';
+  const wallet = new Wallet({ createAccessKeyFor: TOKEN_CONTRACT_ADDRESS });
+
+  await wallet.callMethod({
+    method: 'ft_transfer_call',
+    args: {
+      receiver_id: 'v2.ref-finance.near',
+      amount: '100000000000000000',
+      msg: '',
+    },
+    contractId: TOKEN_CONTRACT_ADDRESS,
+    gas: 300000000000000,
+    deposit: 1,
+  });
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```json
+  "100000000000000000"
+  ```
+
+  </p>
+  </details>
+
+  _The `Wallet` object comes from our [quickstart template](https://github.com/near-examples/hello-near-examples/blob/main/frontend/near-wallet.js)_
+
   </TabItem>
   <TabItem value="🖥️ CLI" label="🖥️ CLI">
-    <CLIAttachTokenToCall />
+
+  ```bash
+  near call token.v2.ref-finance.near ft_transfer_call '{"receiver_id": "v2.ref-finance.near", "amount": "100000000000000000", "msg": ""}' --gas 300000000000000 --depositYocto 1 --accountId bob.near
+  ```
+
+  <details>
+  <summary>Example response</summary>
+  <p>
+
+  ```bash
+  '100000000000000000'
+  ```
+
+  </p>
+  </details>
+
   </TabItem>
   <TabItem value="Lantstool" label={<LantstoolLabel />}>
     <TryOutOnLantstool path="docs/2.build/5.primitives/ft/attach-ft-to-call.json" />
   </TabItem>
   <TabItem value="📄 Contract"  label="📄 Contract"  default>
-    <SmartContractAttachTokenToCall />
+
+  ```rust
+  #[payable]
+  pub fn call_with_attached_tokens(&mut self, receiver_id: AccountId, amount: U128) -> Promise {
+    assert_eq!(env::attached_deposit(), 1, "Requires attached deposit of exactly 1 yoctoNEAR");
+
+    let promise = ext(self.ft_contract.clone())
+      .with_static_gas(Gas(150*TGAS))
+      .with_attached_deposit(YOCTO_NEAR)
+      .ft_transfer_call(receiver_id, amount, None, "".to_string());
+
+    return promise.then( // Create a promise to callback query_greeting_callback
+      Self::ext(env::current_account_id())
+      .with_static_gas(Gas(100*TGAS))
+      .external_call_callback()
+    )
+  }
+  ```
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
**Description :**

This PR updates the primitives docs to inline the .md content directly into the pages : 

- dao.md
- dex.md
- nft.md
- ft.md


**Changes:**
- Removed imports of .md wrappers in primitives folder (DAO, Fungible Token, NFT, etc.)
- Pasted the actual markdown content directly into the files

