### PR TITLE
Rename method EXPERIMENTAL_maintenance_windows to maintenance_windows

### DIFF
--- a/docs/api/rpc/maintenance-windows.md
+++ b/docs/api/rpc/maintenance-windows.md
@@ -17,7 +17,7 @@ The RPC API enables you to query future maintenance windows for a specific valid
 
 | Method | Purpose | Parameters |
 |--------|---------|------------|
-| [`EXPERIMENTAL_maintenance_windows`](#maintenance-windows) | Get validator maintenance windows | `account_id` |
+| [`maintenance_windows`](#maintenance-windows) | Get validator maintenance windows | `account_id` |
 
 ---
 
@@ -30,7 +30,7 @@ The RPC API enables you to query future maintenance windows for a specific valid
     If the provided account is not a validator, then it will return the range
     from now to the end of the epoch.
 
-    - **method**: `EXPERIMENTAL_maintenance_windows`
+    - **method**: `maintenance_windows`
     - **params**:
       - `account_id`: The validator account ID to query
   </SplitLayoutLeft>
@@ -41,7 +41,7 @@ The RPC API enables you to query future maintenance windows for a specific valid
         {
           "jsonrpc": "2.0",
           "id": "dontcare",
-          "method": "EXPERIMENTAL_maintenance_windows",
+          "method": "maintenance_windows",
           "params": {
             "account_id": "node0"
           }
@@ -53,7 +53,7 @@ The RPC API enables you to query future maintenance windows for a specific valid
         http POST https://rpc.testnet.near.org \
           jsonrpc=2.0 \
           id=dontcare \
-          method=EXPERIMENTAL_maintenance_windows \
+          method=maintenance_windows \
           params:='{
             "account_id": "node0"
           }'


### PR DESCRIPTION
In release 2.10 [this PR](https://github.com/near/nearcore/pull/13763) became live and hence this RPC method has been stabilised.  