### PR TITLE
Rename (and fix) changes method to block_effects in block-chunk.md‎ documentation

### DIFF
--- a/docs/api/rpc/block-chunk.md
+++ b/docs/api/rpc/block-chunk.md
@@ -20,7 +20,7 @@ Here's a quick reference table for all the methods in this section:
 | Method | Description | Parameters |
 |--------|-------------|------------|
 | [`block`](#block-details) | Get block details by height, hash, or finality | `finality` OR `block_id` |
-| [`block effects`](#block-effects) | Get changes in a specific block | `finality` OR `block_id` |
+| [`block_effects`](#block-effects) | Get changes in a specific block | `finality` OR `block_id` |
 | [`chunk`](#chunk-details) | Get chunk details by chunk_id or block_id + shard_id | `chunk_id` OR [`block_id`, `shard_id`] |
 
 


### PR DESCRIPTION
The documentation for RPC methods had an error where it mistakenly mixed the `changes` RPC method for accounts with the `changes_in_block` RPC method for blocks. Also  in release 2.10 https://github.com/near/nearcore/pull/13763 `EXPERIMENTAL_changes_in_block` RPC method was renamed to `block_effects` as per the rationale given in this PR: `changes_in_block` RPC method. Hence the docs should be updated.

PS: Potentially the methods `blockChanges` in the near API and `getBlockChanges`  in  Lantstool may have been updated, in that case the examples in block-chunk.md‎ are outdated too.