### PR TITLE
Fix off-by-one in <File> line-range extraction and add regression test

### DIFF
--- a/website/scripts/copy-md-to-static.js
+++ b/website/scripts/copy-md-to-static.js
@@ -54,7 +54,7 @@ function formatCodeBlock(codeData, language = '') {
 
   const codeLines = String(code).split('\n');
   const start = startMatch ? Math.max(parseInt(startMatch[1]) - 1, 0) : 0;
-  const end = endMatch ? parseInt(endMatch[1]) + 1 : codeLines.length;
+  const end = endMatch ? parseInt(endMatch[1]) : codeLines.length;
 
   const selectedCode = codeLines.slice(start, end).join('\n');
 
@@ -314,4 +314,10 @@ This documentation is organized into several main sections: Protocol fundamental
   }
 }
 
-processMarkdownFiles();
+if (require.main === module) {
+  processMarkdownFiles();
+}
+
+module.exports = {
+  formatCodeBlock,
+};

--- a/website/scripts/copy-md-to-static.test.js
+++ b/website/scripts/copy-md-to-static.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { formatCodeBlock } = require('./copy-md-to-static');
+
+test('formatCodeBlock respects inclusive end line numbers', () => {
+  const result = formatCodeBlock(
+    {
+      code: ['line 1', 'line 2', 'line 3', 'line 4'].join('\n'),
+      normalizedTag: '<File url="https://example.com/file.js" start="2" end="3" />',
+    },
+    'js'
+  );
+
+  assert.equal(result, '```js\nline 2\nline 3\n```');
+});
+
+test('formatCodeBlock returns full content when no range is provided', () => {
+  const result = formatCodeBlock(
+    {
+      code: ['alpha', 'beta'].join('\n'),
+      normalizedTag: '<Github url="https://example.com/file.js" />',
+    },
+    'js'
+  );
+
+  assert.equal(result, '```js\nalpha\nbeta\n```');
+});


### PR DESCRIPTION
## Summary
`<File ... start="x" end="y" />` snippet extraction had an off-by-one bug that included one extra line after `end`.

This PR:
- fixes the line-range slicing so `end` does not include the next line
- adds a regression test for `start="2" end="3"` to ensure only lines 2–3 are returned
- adds a small `require.main` guard/export so the helper can be tested directly without changing normal script execution

## Before / After
- Before: `start=2, end=3` returned lines `2, 3, 4`
- After: `start=2, end=3` returns lines `2, 3`

## Testing
```bash
node --test website/scripts/copy-md-to-static.test.js