### PR TITLE
fix: add redirect for /protocol/access-keys

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -74,6 +74,10 @@
     {
       "source": "/chain-abstraction/meta-transactions",
       "destination": "/protocol/transactions/meta-tx"
+    },
+    {
+      "source": "/protocol/access-keys",
+      "destination": "/protocol/accounts-contracts/access-keys"
     }
   ],
   "navigation": {
@@ -330,7 +334,7 @@
                       }
                     ]
                   }
-              ]
+                ]
               },
               {
                 "group": "Multi-Chain",


### PR DESCRIPTION
Fixes #2995

The URL `/protocol/access-keys` returns 404. Added a redirect entry in `docs.json` pointing to the correct location `/protocol/accounts-contracts/access-keys`.