### PR TITLE
Revise GetBlock description for clarity

### DIFF
--- a/data-infrastructure/data-services.mdx
+++ b/data-infrastructure/data-services.mdx
@@ -13,7 +13,7 @@ Data Services are constantly listening to the blockchain, processing the transac
 
 - [The Graph](https://thegraph.com/docs/en/cookbook/near/): development tools to process blockchain events and make the resulting data easily available via a GraphQL API, known individually as a subgraph. [Graph Node](https://github.com/graphprotocol/graph-node) is able to process NEAR events, which means that NEAR developers can build subgraphs to index their smart contracts.
 
-- [GetBlock](https://getblock.io/explorers/near/blocks/): developer tools offering a simple and reliable API access to multiple blockchains including NEAR Protocol.
+- [GetBlock](https://getblock.io/explorers/near/blocks/): developer tools offering a simple and reliable API access for historical data streams and other services for NEAR.
 
 - [Community APIs](./data-api): build precise & reliable dApps with our community's APIs.
 


### PR DESCRIPTION
Updated GetBlock description to emphasize historical data access as some RPC providers were asking why GetBLock is in the list and not themselves.