### PR TITLE
ci: grant write permissions to update-rpc-openapi workflow

### DIFF
--- a/.github/workflows/update-rpc-openapi.yml
+++ b/.github/workflows/update-rpc-openapi.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   update-openapi:
     runs-on: ubuntu-latest
+    # The default GITHUB_TOKEN is read-only; the job needs write access to
+    # push the update-rpc-openapi branch and to open the PR.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

The **Update RPC OpenAPI spec** workflow (`.github/workflows/update-rpc-openapi.yml`) has failed on **every run since it was added** in #3014 — 4 consecutive Mondays (Apr 27, May 4, May 11, May 18). It has never produced a successful run or a single auto-update PR.

Every run fails identically at the `git push` step:

```
remote: Permission to near/docs.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/near/docs/': The requested URL returned error: 403
```

## Cause

This repo's Actions setting is `default_workflow_permissions: "read"`, so the default `GITHUB_TOKEN` is read-only. A workflow that pushes a branch and opens a PR must declare write access explicitly. The workflow shipped in #3014 without a `permissions:` block, so it was dead-on-arrival.

The other steps (download from nearcore, `patch-openapi.js`, commit) all succeed — only the push and PR creation are blocked.

## Fix

Add a job-level `permissions:` block:

- `contents: write` — to push the `update-rpc-openapi` branch
- `pull-requests: write` — for `gh pr create`

The repo already allows Actions to create PRs (`can_approve_pull_request_reviews: true`), so no org/repo setting change is needed.

## Consequence (separate, not fixed here)

Because the sync has never run, the committed `openapi.json` is stale: docs is on spec `1.2.3` while nearcore master is on `1.2.6` (missing the `/EXPERIMENTAL_receipt_to_tx` endpoint, among other changes). Once this merges, triggering the workflow (`gh workflow run update-rpc-openapi.yml`) will open that catch-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)