### PR TITLE
fix: remove leading slash from openapi path in docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,7 +45,7 @@
   },
   "favicon": "assets/favicon.svg",
   "api": {
-    "openapi": "/openapi.json",
+    "openapi": "openapi.json",
     "playground": {
       "display": "interactive"
     },
@@ -579,14 +579,14 @@
           },
           {
             "group": "Query",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /query"
             ]
           },
           {
             "group": "Transactions",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /send_tx",
               "POST /tx",
@@ -598,7 +598,7 @@
           },
           {
             "group": "Accounts",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /EXPERIMENTAL_view_account",
               "POST /changes",
@@ -607,7 +607,7 @@
           },
           {
             "group": "Access Keys",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /EXPERIMENTAL_view_access_key_list",
               "POST /EXPERIMENTAL_view_access_key"
@@ -615,7 +615,7 @@
           },
           {
             "group": "Smart Contracts",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /EXPERIMENTAL_view_code",
               "POST /EXPERIMENTAL_view_state",
@@ -624,14 +624,14 @@
           },
           {
             "group": "Gas Price",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /gas_price"
             ]
           },
           {
             "group": "Blocks & Chunks",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /block",
               "POST /chunk",
@@ -641,7 +641,7 @@
           },
           {
             "group": "Network",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /status",
               "POST /health",
@@ -653,7 +653,7 @@
           },
           {
             "group": "Gas & Config",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /EXPERIMENTAL_protocol_config",
               "POST /genesis_config",
@@ -663,7 +663,7 @@
           },
           {
             "group": "Light Client",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /light_client_proof",
               "POST /next_light_client_block",
@@ -673,7 +673,7 @@
           },
           {
             "group": "Maintenance & Storage",
-            "openapi": "/openapi.json",
+            "openapi": "openapi.json",
             "pages": [
               "POST /maintenance_windows",
               "POST /EXPERIMENTAL_maintenance_windows",


### PR DESCRIPTION
## Problem — production deployments are blocked

The **Mintlify Deployment** of `master` is failing:

> **Deployment Failed** — Failed validating local OpenApi file referenced in docs.json: `/openapi.json`

Run: https://github.com/near/docs/runs/77272760627

While this is failing, docs.near.org is frozen on the last successful build and will not pick up new commits.

## Cause

`docs.json` references the OpenAPI spec as `"openapi": "/openapi.json"` — with a leading slash — in 12 places. Mintlify resolves the leading `/` as an *absolute filesystem path* outside the docs project and rejects it. The file actually lives at the project root (`openapi.json`).

Note: this same check passed earlier — Mintlify's cloud build recently tightened its path validation (it now matches the strict `mint validate` CLI behavior), so the leading slash that was previously tolerated now breaks the deployment.

## Fix

Drop the leading slash in all 12 `openapi` references so the path resolves relative to the project root:

```diff
-    "openapi": "/openapi.json",
+    "openapi": "openapi.json",
```

Verified locally with `mint validate`:

```
success OpenAPI definition is valid.
success build validation passed
```

Only the `openapi` field is affected — `logo`/`favicon`/redirect paths legitimately use leading slashes and are left unchanged.

## Note

Independent of #3041 (which fixes the `update-rpc-openapi` workflow permissions). This one is the urgent fix — it unblocks the live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)