### PR TITLE
fix: normalize JSON Schema 2020-12 constructs in openapi.json for OAS 3.0

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1201,7 +1201,8 @@
                 },
                 "maxItems": 2,
                 "minItems": 2,
-                "type": "array"
+                "type": "array",
+                "description": "Positional tuple of 2: [GasKeyInfo, FunctionCallPermission]."
               }
             },
             "required": [
@@ -3444,7 +3445,8 @@
             "maxItems": 2,
             "minItems": 2,
             "nullable": true,
-            "type": "array"
+            "type": "array",
+            "description": "Positional tuple of 2: [ShardId, AccountId]."
           },
           "signature": {
             "allOf": [
@@ -3622,7 +3624,8 @@
             "additionalProperties": {
               "type": "string"
             },
-            "type": "object"
+            "type": "object",
+            "description": "Object keys must match: `^\\d+$`."
           },
           "sync_block_hash": {
             "$ref": "#/components/schemas/CryptoHash"

--- a/openapi.json
+++ b/openapi.json
@@ -1189,14 +1189,16 @@
             "description": "Gas key with limited permission to make transactions with FunctionCallActions\nGas keys are a kind of access keys with a prepaid balance to pay for gas.",
             "properties": {
               "GasKeyFunctionCall": {
-                "items": [
-                  {
-                    "$ref": "#/components/schemas/GasKeyInfo"
-                  },
-                  {
-                    "$ref": "#/components/schemas/FunctionCallPermission"
-                  }
-                ],
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/GasKeyInfo"
+                    },
+                    {
+                      "$ref": "#/components/schemas/FunctionCallPermission"
+                    }
+                  ]
+                },
                 "maxItems": 2,
                 "minItems": 2,
                 "type": "array"
@@ -1430,7 +1432,6 @@
         "type": "object"
       },
       "AccountId": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "NEAR Account Identifier.\n\nThis is a unique, syntactically valid, human-readable account identifier on the NEAR network.\n\n[See the crate-level docs for information about validation.](index.html#account-id-rules)\n\nAlso see [Error kind precedence](AccountId#error-kind-precedence).\n\n## Examples\n\n```\nuse near_account_id::AccountId;\n\nlet alice: AccountId = \"alice.near\".parse().unwrap();\n\nassert!(\"ƒelicia.near\".parse::<AccountId>().is_err()); // (ƒ is not f)\n```",
         "title": "AccountId",
         "type": "string"
@@ -3430,14 +3431,16 @@
             "description": "TODO(2271): deprecated."
           },
           "shard_split": {
-            "items": [
-              {
-                "$ref": "#/components/schemas/ShardId"
-              },
-              {
-                "$ref": "#/components/schemas/AccountId"
-              }
-            ],
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ShardId"
+                },
+                {
+                  "$ref": "#/components/schemas/AccountId"
+                }
+              ]
+            },
             "maxItems": 2,
             "minItems": 2,
             "nullable": true,
@@ -3616,11 +3619,8 @@
             "type": "array"
           },
           "shard_sync_status": {
-            "additionalProperties": false,
-            "patternProperties": {
-              "^\\d+$": {
-                "type": "string"
-              }
+            "additionalProperties": {
+              "type": "string"
             },
             "type": "object"
           },

--- a/scripts/patch-openapi.js
+++ b/scripts/patch-openapi.js
@@ -14,6 +14,14 @@
 //    single string enum so Mintify renders one dropdown with all six options.
 // 3. Inline the wait_until $ref on RpcSendTransactionRequest and
 //    RpcTransactionStatusRequest so the playground picks up the description.
+// 4. Normalize JSON Schema 2020-12 constructs that nearcore's Rust generator
+//    emits but that Mintlify rejects, since the spec self-declares
+//    `openapi: 3.0.0`. Without this the docs deployment fails to validate:
+//      - tuple-style `items` (an array of schemas, e.g. GasKeyFunctionCall and
+//        BlockHeaderView.shard_split) -> a single schema.
+//      - `patternProperties` (e.g. CatchupStatusView.shard_sync_status) ->
+//        `additionalProperties` holding the value schema.
+//      - bare `$schema`/`$id` metadata keywords (e.g. on AccountId) -> dropped.
 //
 // Run from the repo root: `node scripts/patch-openapi.js`.
 
@@ -36,6 +44,65 @@ const TX_EXECUTION_STATUS_DESCRIPTION = [
 
 const WAIT_UNTIL_DESCRIPTION =
   "Optional. Tells the RPC how long to wait before returning the transaction status. See the TxExecutionStatus enum for the six available milestones. Defaults to `EXECUTED_OPTIMISTIC`.";
+
+// Pure JSON Schema metadata keywords with no meaning in an OpenAPI 3.0 Schema
+// Object. They carry no rendering information, so they are simply removed.
+// `$ref` is deliberately NOT in this list.
+const DROP_KEYWORDS = ["$schema", "$id", "$anchor", "$comment", "$defs"];
+
+// Collapse a list of schemas to a single schema: identical members collapse to
+// that one member, differing members become a `oneOf`.
+function collapseSchemas(schemas) {
+  const unique = [];
+  for (const schema of schemas) {
+    if (!unique.some((u) => JSON.stringify(u) === JSON.stringify(schema))) {
+      unique.push(schema);
+    }
+  }
+  return unique.length === 1 ? unique[0] : { oneOf: unique };
+}
+
+// Walk a schema subtree and rewrite the JSON Schema 2020-12 constructs that
+// OpenAPI 3.0 does not accept (see patch 4 in the header) so Mintlify can
+// validate the spec.
+function normalizeForOas30(node) {
+  const counts = { tupleItems: 0, patternProps: 0, droppedKeywords: 0 };
+  const visit = (n) => {
+    if (Array.isArray(n)) {
+      n.forEach(visit);
+      return;
+    }
+    if (!n || typeof n !== "object") return;
+
+    for (const keyword of DROP_KEYWORDS) {
+      if (keyword in n) {
+        delete n[keyword];
+        counts.droppedKeywords += 1;
+      }
+    }
+
+    // tuple-style `items` (an array of schemas) -> a single schema.
+    if (Array.isArray(n.items)) {
+      n.items = collapseSchemas(n.items);
+      counts.tupleItems += 1;
+    }
+
+    // `patternProperties` -> `additionalProperties`. The key regex is dropped;
+    // the result renders as an open string-keyed map of the value schema.
+    if (n.patternProperties && typeof n.patternProperties === "object") {
+      const valueSchemas = Object.values(n.patternProperties);
+      if (valueSchemas.length > 0) {
+        n.additionalProperties = collapseSchemas(valueSchemas);
+      }
+      delete n.patternProperties;
+      counts.patternProps += 1;
+    }
+
+    for (const value of Object.values(n)) visit(value);
+  };
+  visit(node);
+  return counts;
+}
 
 function patch(spec) {
   const schemas = spec.components.schemas;
@@ -103,7 +170,9 @@ function patch(spec) {
     }
   }
 
-  return { fixedRequestSchemas, flattened, inlined };
+  const oas30 = normalizeForOas30(schemas);
+
+  return { fixedRequestSchemas, flattened, inlined, oas30 };
 }
 
 function main() {
@@ -113,12 +182,15 @@ function main() {
   }
 
   const spec = JSON.parse(fs.readFileSync(SPEC_PATH, "utf8"));
-  const { fixedRequestSchemas, flattened, inlined } = patch(spec);
+  const { fixedRequestSchemas, flattened, inlined, oas30 } = patch(spec);
   fs.writeFileSync(SPEC_PATH, JSON.stringify(spec, null, 2) + "\n");
 
   console.log(`Patched ${fixedRequestSchemas} JsonRpcRequest_for_* schemas`);
   console.log(`TxExecutionStatus flattened: ${flattened}`);
   console.log(`wait_until $refs inlined: ${inlined}`);
+  console.log(`tuple items collapsed: ${oas30.tupleItems}`);
+  console.log(`patternProperties rewritten: ${oas30.patternProps}`);
+  console.log(`metadata keywords dropped: ${oas30.droppedKeywords}`);
 }
 
 main();

--- a/scripts/patch-openapi.js
+++ b/scripts/patch-openapi.js
@@ -18,10 +18,13 @@
 //    emits but that Mintlify rejects, since the spec self-declares
 //    `openapi: 3.0.0`. Without this the docs deployment fails to validate:
 //      - tuple-style `items` (an array of schemas, e.g. GasKeyFunctionCall and
-//        BlockHeaderView.shard_split) -> a single schema.
+//        BlockHeaderView.shard_split) -> a single schema, with the original
+//        positional order recorded in the description.
 //      - `patternProperties` (e.g. CatchupStatusView.shard_sync_status) ->
-//        `additionalProperties` holding the value schema.
-//      - bare `$schema`/`$id` metadata keywords (e.g. on AccountId) -> dropped.
+//        `additionalProperties`, with the key pattern recorded in the
+//        description.
+//      - pure metadata keywords `$schema`/`$comment` (e.g. on AccountId) ->
+//        dropped.
 //
 // Run from the repo root: `node scripts/patch-openapi.js`.
 
@@ -45,10 +48,12 @@ const TX_EXECUTION_STATUS_DESCRIPTION = [
 const WAIT_UNTIL_DESCRIPTION =
   "Optional. Tells the RPC how long to wait before returning the transaction status. See the TxExecutionStatus enum for the six available milestones. Defaults to `EXECUTED_OPTIMISTIC`.";
 
-// Pure JSON Schema metadata keywords with no meaning in an OpenAPI 3.0 Schema
-// Object. They carry no rendering information, so they are simply removed.
-// `$ref` is deliberately NOT in this list.
-const DROP_KEYWORDS = ["$schema", "$id", "$anchor", "$comment", "$defs"];
+// Pure JSON Schema metadata keywords that carry no structural meaning and are
+// safe to delete from an OpenAPI 3.0 Schema Object. Reference-bearing keywords
+// such as `$ref`, `$defs`, `$id` and `$anchor` are deliberately excluded: a
+// `$ref` can resolve into them, so dropping them could silently break the
+// spec. If nearcore ever emits those, validation should fail loudly instead.
+const DROP_KEYWORDS = ["$schema", "$comment"];
 
 // Collapse a list of schemas to a single schema: identical members collapse to
 // that one member, differing members become a `oneOf`.
@@ -62,9 +67,24 @@ function collapseSchemas(schemas) {
   return unique.length === 1 ? unique[0] : { oneOf: unique };
 }
 
+// Short human-readable label for a schema, used in generated descriptions.
+function schemaLabel(schema) {
+  if (schema && typeof schema.$ref === "string") {
+    return schema.$ref.split("/").pop();
+  }
+  if (schema && typeof schema.type === "string") return schema.type;
+  return "schema";
+}
+
+// Append a note to a schema's `description`, keeping anything already there.
+function appendDescription(node, note) {
+  node.description = node.description ? `${node.description}\n\n${note}` : note;
+}
+
 // Walk a schema subtree and rewrite the JSON Schema 2020-12 constructs that
 // OpenAPI 3.0 does not accept (see patch 4 in the header) so Mintlify can
-// validate the spec.
+// validate the spec. OAS 3.0 cannot express tuple ordering or key-name
+// patterns structurally, so that information is preserved in the description.
 function normalizeForOas30(node) {
   const counts = { tupleItems: 0, patternProps: 0, droppedKeywords: 0 };
   const visit = (n) => {
@@ -81,20 +101,36 @@ function normalizeForOas30(node) {
       }
     }
 
-    // tuple-style `items` (an array of schemas) -> a single schema.
+    // tuple-style `items` (an array of schemas) -> a single schema. The
+    // collapsed form no longer encodes which schema goes in which position,
+    // so record the original order before rewriting.
     if (Array.isArray(n.items)) {
+      const order = n.items.map(schemaLabel);
+      appendDescription(
+        n,
+        `Positional tuple of ${order.length}: [${order.join(", ")}].`,
+      );
       n.items = collapseSchemas(n.items);
       counts.tupleItems += 1;
     }
 
-    // `patternProperties` -> `additionalProperties`. The key regex is dropped;
-    // the result renders as an open string-keyed map of the value schema.
+    // `patternProperties` -> `additionalProperties`. OAS 3.0 cannot constrain
+    // key names, so record the required key pattern(s) before rewriting.
     if (n.patternProperties && typeof n.patternProperties === "object") {
+      const patterns = Object.keys(n.patternProperties);
       const valueSchemas = Object.values(n.patternProperties);
       if (valueSchemas.length > 0) {
         n.additionalProperties = collapseSchemas(valueSchemas);
       }
       delete n.patternProperties;
+      if (patterns.length > 0) {
+        appendDescription(
+          n,
+          `Object keys must match: ${patterns
+            .map((p) => `\`${p}\``)
+            .join(", ")}.`,
+        );
+      }
       counts.patternProps += 1;
     }
 


### PR DESCRIPTION
## Problem — Mintlify deployment of `master` still fails

After #3043 fixed the `/openapi.json` path, the next `master` deployment fails on schema validation:

> Failed to validate OpenAPI schema:`/components/schemas/AccessKeyPermission`: must have required property `$ref`

## Cause

#3042 auto-pulled the spec from nearcore (`1.2.3` → `1.2.6`). The new spec contains JSON Schema 2020-12 / OpenAPI 3.1 constructs, but `openapi.json` self-declares `openapi: 3.0.0`, so Mintlify rejects it. nearcore's Rust schema generator emits these for newly added types (gas keys, shard splitting):

| Construct | Where | Why invalid in OAS 3.0 |
|---|---|---|
| tuple-style `items` (array of schemas) | `AccessKeyPermission.GasKeyFunctionCall`, `BlockHeaderView.shard_split` | OAS 3.0 allows only a single `items` schema |
| `$schema` metadata keyword | `AccountId` | not a valid Schema Object keyword |
| `patternProperties` | `CatchupStatusView.shard_sync_status` | not supported in OAS 3.0 |

I scanned the whole spec for every 2020-12-only keyword — these three are the complete set.

## Fix

Extend `scripts/patch-openapi.js` with a normalization pass (**patch 4**) and regenerate `openapi.json`:

- tuple `items` → a single schema (`oneOf` of the members); the existing `minItems`/`maxItems` keep the length pinned.
- `patternProperties` → `additionalProperties` holding the value schema (renders as an open string-keyed map; the key regex is dropped).
- bare `$schema`/`$id`-style metadata keywords → dropped.

The patch lives in `patch-openapi.js` so the **weekly nearcore sync re-applies it** — a direct edit to `openapi.json` would be clobbered on the next run. `openapi.json` is regenerated in this PR so the fix deploys immediately.

Verified locally with `mint validate`:

```
success OpenAPI definition is valid.
success build validation passed
```

## Context

Third in a chain: #3041 (workflow permissions) → #3042 (auto-pulled the new spec) → #3043 (path leading slash) → **this** (the new spec's 3.1 constructs). With this merged, the `master` Mintlify deployment should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)