### PR TITLE
ci: bump actions/checkout to v5 (Node.js 24)

### DIFF
--- a/.github/workflows/update-rpc-openapi.yml
+++ b/.github/workflows/update-rpc-openapi.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download openapi.json from nearcore
         run: |


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating Node.js 20. `actions/checkout@v4` runs on Node.js 20 and triggers this runner warning:

> Node.js 20 actions are deprecated. [...] Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

This bumps `actions/checkout` to `v5`, which runs on Node.js 24, in `.github/workflows/update-rpc-openapi.yml` — the only workflow and only JS action affected.

## Notes

The other steps in that workflow (`curl`, `node`, `gh`) are plain shell commands, not JS actions, so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)