### PR TITLE
fix: restore epoch duration from PR #2984

### DIFF
--- a/protocol/network/epoch.mdx
+++ b/protocol/network/epoch.mdx
@@ -7,10 +7,10 @@ This section explains the concept of an **epoch** in the NEAR Protocol, which is
 
 An **epoch** is a unit of time when validators of the network remain constant. It is measured in blocks:
 
-- Both `testnet` and `mainnet` have an epoch duration of 43,200 blocks. Ideally epochs last about 12 hours, since blocks are created every second (in reality, they take slightly longer to be created).
+- Both `testnet` and `mainnet` have an epoch duration of 43,200 blocks. Ideally epochs last 7.2 hours, since blocks are created every 0.6 seconds (in reality, they can take slightly shorter or longer to be created).
 - You can view this setting by querying the **[`protocol_config`](/api/rpc/protocol#protocol-config)** RPC endpoint and searching for `epoch_length`.
 
-**Note:** Nodes garbage collect blocks after 5 epochs (~2.5 days) unless they are [archival nodes](https://near-nodes.io/intro/node-types#archival-node).
+**Note:** Nodes garbage collect blocks after 5 epochs (~1.5 days) unless they are [archival nodes](https://near-nodes.io/intro/node-types#archival-node).
 
 **Example:**
 


### PR DESCRIPTION
Restores the epoch timing data from #2984 that was lost during the Mintlify migration in #2988.

Specifically, this updates `protocol/network/epoch.mdx` to say:

- epochs ideally last 7.2 hours based on 0.6s block time
- 5 epochs of garbage-collected blocks is ~1.5 days

This matches the change introduced in near/docs@6086fef743e5dc22c24f07c497b290e61d99d6eb.