### PR TITLE
docs(rpc): add EXPERIMENTAL_receipt_to_tx to RPC nav

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -620,6 +620,7 @@
               "POST /tx",
               "POST /EXPERIMENTAL_tx_status",
               "POST /EXPERIMENTAL_receipt",
+              "POST /EXPERIMENTAL_receipt_to_tx",
               "POST /broadcast_tx_async",
               "POST /broadcast_tx_commit"
             ]


### PR DESCRIPTION
## What

Adds `POST /EXPERIMENTAL_receipt_to_tx` to the **Transactions** group `pages` list in `docs.json`, right after `EXPERIMENTAL_receipt`.

## Why

The `EXPERIMENTAL_receipt_to_tx` endpoint (resolves a `receipt_id` back to its originating transaction) already exists in `openapi.json` but was never added to the nav, so the page never rendered in the RPC sidebar.

## Scope

- Single nav line. Does **not** touch `openapi.json` — spec content is maintained by the `update-rpc-openapi` workflow (PR #3049), which upgrades the endpoint to the full hint-param shape. Kept separate to avoid conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)