### PR TITLE
docs: add 'How to verify:' line to smart contract security checklist for consistency

### DIFF
--- a/smart-contracts/security/checklist.mdx
+++ b/smart-contracts/security/checklist.mdx
@@ -197,6 +197,7 @@ self.set_balance(&user_id, 0); // Too late!
 
 **Why it matters**: Prevents external actors from calling your callbacks directly and bypassing security checks.
 
+**How to verify:**
 ```rust
 // ✅ CORRECT - Callback method can be called only by contract itself
 #[private]


### PR DESCRIPTION
Adding a "**How to verify:**" line under the checklist item "### 8. All Private Callbacks Are Marked as `private`" for consistency with other items, right above the code snippet.