### PR TITLE
docs: document gas keys (NEP-611) and DelegateV2 meta transactions

### DIFF
--- a/api/rpc/contracts.mdx
+++ b/api/rpc/contracts.mdx
@@ -14,6 +14,7 @@ The RPC API enables you to view details about accounts and contracts as well as 
 | [`view_account_changes`](#view-account-changes) | Monitor account state changes |
 | [`view_access_key`](#view-access-key) | Get the nonce and permissions of a single access key |
 | [`view_access_key_list`](#view-access-key-list) | List all access keys on an account |
+| [`view_gas_key_nonces`](#view-gas-key-nonces) | List the parallel nonces of a gas key |
 | [`view_code`](#view-contract-code) | Get deployed contract WASM code |
 | [`view_state`](#view-contract-state) | Get contract storage data |
 | [`data_changes`](#view-contract-state-changes) | Monitor contract state changes |
@@ -201,6 +202,19 @@ For a function-call key, `permission` is an object instead of the `"FullAccess"`
   }
 }
 ```
+
+For a [gas key](/protocol/accounts-contracts/access-keys#gas-keys), `permission` also carries the key's prepaid balance and number of nonce lanes:
+
+```json
+"permission": {
+  "GasKeyFullAccess": {
+    "balance": "5000000000000000000000000",
+    "num_nonces": 8
+  }
+}
+```
+
+The nonces of the individual lanes are not included — query them with [`view_gas_key_nonces`](#view-gas-key-nonces).
 </Accordion>
 
 <Note>
@@ -284,6 +298,79 @@ Returns all [access keys](/protocol/accounts-contracts/access-keys) for an accou
 
 <Note>
 Post-quantum [`ml-dsa-65`](/protocol/accounts-contracts/access-keys#signature-schemes) keys are stored on-chain by hash, so they appear here with an `ml-dsa-65-hash:` prefix (a base58-encoded 32-byte SHA3-256 digest) rather than the full `ml-dsa-65:` key. To match an entry to one of your own keys, derive its handle — the SHA3-256 of the domain-separation tag `near:ml-dsa-65-pubkey-hash:v1` followed by the raw public key — and compare it against the returned value (hashing the key without that prefix will not match).
+</Note>
+
+---
+
+## View Gas Key Nonces
+
+Returns the current nonce of every parallel nonce lane of a [gas key](/protocol/accounts-contracts/access-keys#gas-keys), given the account and the key's public key. The array is indexed by `nonce_index`: the first element is lane `0`, the second is lane `1`, and so on. Use [`view_access_key`](#view-access-key) to see the gas key's balance and permission.
+
+- **method**: `query`
+- **params**: `request_type: view_gas_key_nonces`, `finality` OR `block_id`, `account_id`, `public_key`
+
+<Tabs>
+  <Tab title="JSON">
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": "dontcare",
+      "method": "query",
+      "params": {
+        "request_type": "view_gas_key_nonces",
+        "finality": "final",
+        "account_id": "account.rpc-examples.testnet",
+        "public_key": "ed25519:DCkbTMS8s4kqV4nGvz5kRBdNbY9YwjjvNGNXKpAg2eFa"
+      }
+    }
+    ```
+  </Tab>
+  <Tab title="JavaScript">
+    ```js
+    import { JsonRpcProvider } from "near-api-js";
+
+    const provider = new JsonRpcProvider({ url: "https://test.rpc.fastnear.com" });
+
+    const response = await provider.query({
+      request_type: 'view_gas_key_nonces',
+      finality: 'final',
+      account_id: 'account.rpc-examples.testnet',
+      public_key: 'ed25519:DCkbTMS8s4kqV4nGvz5kRBdNbY9YwjjvNGNXKpAg2eFa',
+    });
+    ```
+  </Tab>
+  <Tab title="HTTPie">
+    ```bash
+    http POST https://rpc.testnet.near.org \
+      jsonrpc=2.0 id=dontcare method=query \
+      params:='{"request_type":"view_gas_key_nonces","finality":"final","account_id":"account.rpc-examples.testnet","public_key":"ed25519:DCkbTMS8s4kqV4nGvz5kRBdNbY9YwjjvNGNXKpAg2eFa"}'
+    ```
+  </Tab>
+</Tabs>
+
+<Accordion title="Example response">
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "nonces": [
+      187438921000012,
+      187438921000003,
+      187438921000000,
+      187438921000000
+    ],
+    "block_hash": "56xEo2LorUFVNbkFhCncFSWNiobdp1kzm14nZ47b5JVW",
+    "block_height": 187440904
+  },
+  "id": "dontcare"
+}
+```
+
+Each lane starts at `block_height * 10^6` from when the key was added and advances independently as transactions use it.
+</Accordion>
+
+<Note>
+Querying a key that exists but is not a gas key (or does not exist at all) returns an `UnknownGasKey` error.
 </Note>
 
 ---
@@ -535,6 +622,7 @@ Allows you to call a contract method as a view function (read-only).
 | `UnknownAccount` | Account does not exist | Check account ID spelling |
 | `InvalidAccount` | Invalid account format | Use valid account ID (e.g., `account.near`) |
 | `UnknownBlock` | Block not found | Use a valid block hash or height |
+| `UnknownGasKey` | Key is not a gas key or does not exist | Check the public key and that it was added as a gas key |
 | `GarbageCollectedBlock` | Block too old | Use archival node or more recent block |
 | `NoContractCode` | No contract deployed | Verify the account has a deployed contract |
 | `MethodNotFound` | Contract method does not exist | Check method name and contract ABI |

--- a/api/rpc/contracts.mdx
+++ b/api/rpc/contracts.mdx
@@ -203,13 +203,27 @@ For a function-call key, `permission` is an object instead of the `"FullAccess"`
 }
 ```
 
-For a [gas key](/protocol/accounts-contracts/access-keys#gas-keys), `permission` also carries the key's prepaid balance and number of nonce lanes:
+For a [gas key](/protocol/accounts-contracts/access-keys#gas-keys), `permission` also carries the key's prepaid `balance` and number of nonce lanes (`num_nonces`). A full-access gas key uses `GasKeyFullAccess`:
 
 ```json
 "permission": {
   "GasKeyFullAccess": {
     "balance": "5000000000000000000000000",
     "num_nonces": 8
+  }
+}
+```
+
+A function-call gas key uses `GasKeyFunctionCall`, which is a flat object carrying the same function-call restrictions (`allowance`, `receiver_id`, `method_names`) as `FunctionCall`, alongside the gas-key `balance` and `num_nonces`:
+
+```json
+"permission": {
+  "GasKeyFunctionCall": {
+    "balance": "5000000000000000000000000",
+    "num_nonces": 8,
+    "allowance": "250000000000000000000000",
+    "receiver_id": "contract.rpc-examples.testnet",
+    "method_names": ["get_greeting"]
   }
 }
 ```

--- a/protocol/accounts-contracts/access-keys.mdx
+++ b/protocol/accounts-contracts/access-keys.mdx
@@ -19,6 +19,8 @@ In NEAR we distinguish two types of Access Keys:
 1. `Full-Access Keys`: Have full control over the account, and should **never be shared**
 2. `Function-Call Keys`: Can only sign calls for specific contracts, and are **meant to be shared**
 
+In addition, a key of either type can be created as a [**gas key**](#gas-keys): a key that carries its own prepaid gas balance and multiple independent nonces, built for sending many transactions in parallel.
+
 Every account in NEAR can hold **multiple keys**, and keys can be added or removed, allowing a
 fine-grained control over the account's permissions.
 
@@ -55,6 +57,57 @@ You should never share your `Full-Access`, otherwise you are giving **total cont
 <Tip>
 [Implicit accounts](./account-id#implicit-address) already have a `Full-Access Key` by default, while for [`named accounts`](./account-id#named-address) their first `Full-Access Key` is added on creation
 </Tip>
+
+---
+
+## Gas Keys
+
+Gas keys ([NEP-611](https://github.com/near/NEPs/pull/611)) are access keys designed for **sending many transactions in parallel**. They were introduced in nearcore 2.13 (protocol version 85) and differ from regular access keys in two ways:
+
+1. **Prepaid gas balance**: a gas key holds its own NEAR balance, and transactions signed with it pay gas from that balance instead of the account's main balance
+2. **Parallel nonces**: a gas key has up to **1,024 independent nonces** (called *nonce lanes*), so many transactions can be in flight at once without nonce collisions
+
+A gas key can have either `FullAccess` or `FunctionCall` permission, with one restriction: a function-call gas key cannot set an `allowance` — its prepaid balance already serves as the gas budget.
+
+This makes gas keys ideal for **programmatic senders** — relayers, bots, exchanges, or a fleet of agents operating one account — which previously had to juggle many separate access keys just to avoid nonce collisions, and risked draining the account's main balance on gas.
+
+### Lifecycle of a Gas Key
+
+A gas key is managed with the same actions as any other key, plus two new actions to move NEAR in and out of its balance:
+
+1. **Create**: an `AddKey` action with a gas-key permission creates the key, specifying its number of nonces (`num_nonces`, between 1 and 1,024). The key is always created with **zero balance**
+2. **Fund**: a `TransferToGasKey` action moves NEAR from the account's balance into the gas key's balance. It can be used repeatedly to top up the key
+3. **Use**: transactions signed with the gas key specify a `nonce_index` selecting which nonce lane to use, and consume gas from the key's balance
+4. **Withdraw**: a `WithdrawFromGasKey` action moves NEAR from the key's balance back to the account. Only the account itself can withdraw
+5. **Delete**: a `DeleteKey` action removes the key. Any remaining balance is **burned**, so the action fails if the key holds more than 1 NEAR — withdraw first, then delete
+
+<Warning>
+Deleting a gas key **burns** whatever balance is left on it — this is a protocol-level protection against spam attacks, not a bug. Always `WithdrawFromGasKey` before deleting. The deletion (and likewise `DeleteAccount`) fails if more than 1 NEAR would be burned, protecting you from losing significant funds by accident.
+</Warning>
+
+### How Gas Keys Pay for Transactions
+
+When a transaction is signed with a gas key:
+
+- The **gas costs** (both burned gas and gas prepaid for function calls) are charged to the **gas key's balance**
+- Any **attached NEAR** (deposits, transfers) is still paid from the **account's main balance**
+- **Gas refunds** for unspent gas return to the **gas key's balance**, so the key sustains itself between top-ups, while balance refunds go to the account
+
+If the gas key's balance cannot cover a transaction's gas, the transaction is rejected. If the gas is covered but the account cannot pay the attached deposit at execution time, the transaction fails **and the burned gas is still charged** to the gas key.
+
+### Using Nonce Lanes
+
+Each of the key's `num_nonces` lanes keeps its own independent nonce. A transaction signed with a gas key picks a lane through a `nonce_index` field (from `0` to `num_nonces - 1`), and only that lane's nonce advances. Two transactions on different lanes can never conflict, so a sender can run one lane per worker and submit transactions concurrently — with a single key to manage.
+
+You can inspect a gas key's lanes with the [`view_gas_key_nonces`](/api/rpc/contracts#view-gas-key-nonces) RPC query, and gas keys appear in [`view_access_key`](/api/rpc/contracts#view-access-key) with their `balance` and `num_nonces`.
+
+<Note>
+**Tooling support**
+
+You can create and manage gas keys with the [NEAR CLI](/tools/cli#gas-keys) (`near account add-key ... grant-gas-key-full-access`, `fund-gas-key`, `withdraw-from-gas-key`, `view-gas-key-nonces`) and with the [`near-kit-rs`](https://github.com/r-near/near-kit-rs) Rust library. Contracts can also add and fund gas keys through batch-promise host functions — though only the account's own transactions can withdraw from one.
+</Note>
+
+Gas keys also work with meta transactions: the new [`DelegateV2`](/protocol/transactions/meta-tx#delegatev2-meta-transactions-with-gas-keys) action lets a user sign a delegate action on a gas key's nonce lane, enabling relayers to sponsor gas end to end.
 
 ---
 

--- a/protocol/accounts-contracts/access-keys.mdx
+++ b/protocol/accounts-contracts/access-keys.mdx
@@ -62,7 +62,7 @@ You should never share your `Full-Access`, otherwise you are giving **total cont
 
 ## Gas Keys
 
-Gas keys ([NEP-611](https://github.com/near/NEPs/pull/611)) are access keys designed for **sending many transactions in parallel**. They were introduced in nearcore 2.13 (protocol version 85) and differ from regular access keys in two ways:
+Gas keys ([NEP-611](https://github.com/near/NEPs/pull/611)) are access keys designed for **sending many transactions in parallel**. They were introduced in nearcore 2.13 (protocol version 86) and differ from regular access keys in two ways:
 
 1. **Prepaid gas balance**: a gas key holds its own NEAR balance, and transactions signed with it pay gas from that balance instead of the account's main balance
 2. **Parallel nonces**: a gas key has up to **1,024 independent nonces** (called *nonce lanes*), so many transactions can be in flight at once without nonce collisions

--- a/protocol/accounts-contracts/access-keys.mdx
+++ b/protocol/accounts-contracts/access-keys.mdx
@@ -104,7 +104,7 @@ You can inspect a gas key's lanes with the [`view_gas_key_nonces`](/api/rpc/cont
 <Note>
 **Tooling support**
 
-You can create and manage gas keys with the [NEAR CLI](/tools/cli#gas-keys) (`near account add-key ... grant-gas-key-full-access`, `fund-gas-key`, `withdraw-from-gas-key`, `view-gas-key-nonces`) and with the [`near-kit-rs`](https://github.com/r-near/near-kit-rs) Rust library. Contracts can also add and fund gas keys through batch-promise host functions — though only the account's own transactions can withdraw from one.
+You can create and manage gas keys with the [NEAR CLI](/tools/cli#gas-keys) (`near account add-key ... grant-gas-key-full-access`, `fund-gas-key`, `withdraw-from-gas-key`, `view-gas-key-nonces`) and from your app with the [`near-kit`](https://github.com/r-near/near-kit) (TypeScript) and [`near-kit-rs`](https://github.com/r-near/near-kit-rs) (Rust) libraries — both cover creating, funding, withdrawing, signing on a nonce lane, and reading a key's lanes via `view_gas_key_nonces`. Contracts can also add and fund gas keys through batch-promise host functions — though only the account's own transactions can withdraw from one.
 </Note>
 
 Gas keys also work with meta transactions: the new [`DelegateV2`](/protocol/transactions/meta-tx#delegatev2-meta-transactions-with-gas-keys) action lets a user sign a delegate action on a gas key's nonce lane, enabling relayers to sponsor gas end to end.

--- a/protocol/transactions/gas.mdx
+++ b/protocol/transactions/gas.mdx
@@ -140,6 +140,10 @@ Prior to protocol version 78, the gas prices of each block was used for the work
 
 You don't buy gas, instead, the gas fee is automatically removed from your account's balance when the transaction [is first processed](./transaction-execution#block-1-the-transaction-arrives) based on the action's gas cost and the network's gas price.
 
+<Note>
+Transactions signed with a [gas key](/protocol/accounts-contracts/access-keys#gas-keys) instead pay their gas fee from the key's own prepaid balance, and gas refunds return to the key.
+</Note>
+
 The only exception to this rule is when you make a function call to a contract. In this case, you need to define how many gas units to use, up to a maximum value of `300Tgas`. This amount will be converted to NEAR using the network's gas price and deducted from your account's balance.
 
 If the transaction ends up using less gas than the amount deducted, the difference will simply be **refunded to your account**. However, the network subtracts a **gas refund fee** of at least 1 Tgas or up to 5% of the unspent gas.

--- a/protocol/transactions/meta-tx.mdx
+++ b/protocol/transactions/meta-tx.mdx
@@ -132,6 +132,8 @@ This unlocks gas sponsorship at both ends of the relay:
 
 The original `DelegateAction` is not deprecated and keeps working as before. All existing constraints apply to both versions: a transaction can contain only one delegate action (of either version), and delegate actions cannot be nested.
 
+You can build and sign `DelegateV2` actions today with the [NEAR CLI](/tools/cli#gas-keys) (on a relayer-configured network connection, selecting the gas key's lane with `--nonce-index`) and with the [`near-kit`](https://github.com/r-near/near-kit) (TypeScript) and [`near-kit-rs`](https://github.com/r-near/near-kit-rs) (Rust) libraries.
+
 <Note>
 The versioned payload is part of what the user signs, and V1 and V2 use different [NEP-461](https://github.com/near/NEPs/pull/461) signing prefixes — a signature produced for one version can never be replayed as the other.
 </Note>

--- a/protocol/transactions/meta-tx.mdx
+++ b/protocol/transactions/meta-tx.mdx
@@ -99,6 +99,45 @@ There are multiple reasons to use a relayer:
 
 ---
 
+## DelegateV2: Meta Transactions with Gas Keys
+
+Since nearcore 2.13 (protocol version 85), there is a second version of the delegate action, `DelegateV2`, introduced alongside [gas keys](/protocol/accounts-contracts/access-keys#gas-keys) in [NEP-611](https://github.com/near/NEPs/pull/611).
+
+`DelegateV2` is identical to the original `DelegateAction` except for one field: its `nonce` can be either a plain nonce (like V1) or a **gas key nonce** — a `nonce` plus a `nonce_index` selecting one of the signing key's parallel nonce lanes. This means a user can sign meta transactions with a **gas key**, which is not possible with V1:
+
+```json
+{
+  "DelegateV2": {
+    "delegate_action": {
+      "V2": {
+        "sender_id": "alice.near",
+        "receiver_id": "ft.near",
+        "actions": [ ... ],
+        "nonce": { "GasKeyNonce": { "nonce": 187310139000002, "nonce_index": 1 } },
+        "max_block_height": 187440000,
+        "public_key": "ed25519:..."
+      }
+    },
+    "signature": "ed25519:..."
+  }
+}
+```
+
+The nonce variant must match the key that signed: a delegate action carrying a `GasKeyNonce` must be signed by a gas key, and a plain-nonce delegate action must be signed by a regular access key — mismatches are rejected.
+
+This unlocks gas sponsorship at both ends of the relay:
+
+- **The user's side**: signing on a gas key's nonce lanes lets a user (or an automated fleet acting as one account) keep many meta transactions in flight concurrently, since each lane's nonce advances independently. Note that in a meta transaction the user's gas key contributes its **nonce lanes**, not its balance — the relayer still pays all gas
+- **The relayer's side**: the relayer can sign the wrapping transaction with its **own gas key**, paying gas from the key's prepaid balance on one of its lanes — solving the nonce-collision problem that high-volume relayers traditionally work around by rotating dozens of access keys
+
+The original `DelegateAction` is not deprecated and keeps working as before. All existing constraints apply to both versions: a transaction can contain only one delegate action (of either version), and delegate actions cannot be nested.
+
+<Note>
+The versioned payload is part of what the user signs, and V1 and V2 use different [NEP-461](https://github.com/near/NEPs/pull/461) signing prefixes — a signature produced for one version can never be replayed as the other.
+</Note>
+
+---
+
 ## Limitations
 
 ### Single receiver
@@ -113,6 +152,10 @@ Any transaction, including meta transactions, must use NONCEs to avoid replay
 attacks. The NONCE must be chosen by Alice and compared to a NONCE stored on
 chain. This NONCE is stored on the access key information that gets initialized
 when creating an account.
+
+With [`DelegateV2`](#delegatev2-meta-transactions-with-gas-keys), the NONCE can
+belong to one of a [gas key](/protocol/accounts-contracts/access-keys#gas-keys)'s
+parallel nonce lanes instead of a regular access key.
 
 ---
 

--- a/protocol/transactions/meta-tx.mdx
+++ b/protocol/transactions/meta-tx.mdx
@@ -101,7 +101,7 @@ There are multiple reasons to use a relayer:
 
 ## DelegateV2: Meta Transactions with Gas Keys
 
-Since nearcore 2.13 (protocol version 85), there is a second version of the delegate action, `DelegateV2`, introduced alongside [gas keys](/protocol/accounts-contracts/access-keys#gas-keys) in [NEP-611](https://github.com/near/NEPs/pull/611).
+Since nearcore 2.13 (protocol version 86), there is a second version of the delegate action, `DelegateV2`, introduced alongside [gas keys](/protocol/accounts-contracts/access-keys#gas-keys) in [NEP-611](https://github.com/near/NEPs/pull/611).
 
 `DelegateV2` is identical to the original `DelegateAction` except for one field: its `nonce` can be either a plain nonce (like V1) or a **gas key nonce** — a `nonce` plus a `nonce_index` selecting one of the signing key's parallel nonce lanes. This means a user can sign meta transactions with a **gas key**, which is not possible with V1:
 

--- a/protocol/transactions/transaction-anatomy.mdx
+++ b/protocol/transactions/transaction-anatomy.mdx
@@ -29,6 +29,7 @@ Each transaction has exactly one `Signer` and `Receiver`, but can have multiple 
 - A transaction is accepted only if the `nonce` value is in the range of:
   - `[(current_nonce_of_access_key + 1) .. (block_height * 10^6)]`
 - Once a transaction is accepted, the access key's `nonce` is set to the `nonce` value of the included transaction
+- A transaction signed with a [gas key](/protocol/accounts-contracts/access-keys#gas-keys) additionally specifies a `nonce_index` selecting one of the key's parallel nonce lanes; the same rules then apply to that lane's nonce independently
 </Info>
 
 ---
@@ -44,11 +45,13 @@ Each transaction can have **one or multiple** [`Actions`](https://nomicon.io/Run
 5. [`UseGlobalContract`](https://nomicon.io/RuntimeSpec/Actions.html#useglobalcontractaction): uses a registered global contract by contract hash or account ID
 6. [`CreateAccount`](https://nomicon.io/RuntimeSpec/Actions.html#createaccountaction): to create a new sub-account (e.g. `ana.near` can create `sub.ana.near`)
 7. [`DeleteAccount`](https://nomicon.io/RuntimeSpec/Actions.html#deleteaccountaction): to delete the account (transferring the remaining balance to a beneficiary)
-8. [`AddKey`](https://nomicon.io/RuntimeSpec/Actions.html#addkeyaction): to add a new key to the account (either `FullAccess` or `FunctionCall` access)
+8. [`AddKey`](https://nomicon.io/RuntimeSpec/Actions.html#addkeyaction): to add a new key to the account (either `FullAccess` or `FunctionCall` access, optionally as a [gas key](/protocol/accounts-contracts/access-keys#gas-keys))
 9. [`DeleteKey`](https://nomicon.io/RuntimeSpec/Actions.html#deletekeyaction): to delete an existing key from the account
-10. [`DelegateActions`](https://nomicon.io/RuntimeSpec/Actions.html#delegate-actions): to create a meta-transaction
-11. [`Stake`](https://nomicon.io/RuntimeSpec/Actions.html#stakeaction): special action to express interest in becoming a network validator
-12. [`DeterministicStateInit`](https://nomicon.io/RuntimeSpec/Actions.html#deterministicstateinitaction): special action to create a deterministic account (an advanced kind of implicit account)
+10. [`TransferToGasKey`](/protocol/accounts-contracts/access-keys#gas-keys): to fund a gas key's prepaid gas balance with NEAR
+11. [`WithdrawFromGasKey`](/protocol/accounts-contracts/access-keys#gas-keys): to move NEAR from a gas key's balance back to the account
+12. [`DelegateActions`](https://nomicon.io/RuntimeSpec/Actions.html#delegate-actions): to create a [meta-transaction](/protocol/transactions/meta-tx) (`Delegate`, or `DelegateV2` for gas-key support)
+13. [`Stake`](https://nomicon.io/RuntimeSpec/Actions.html#stakeaction): special action to express interest in becoming a network validator
+14. [`DeterministicStateInit`](https://nomicon.io/RuntimeSpec/Actions.html#deterministicstateinitaction): special action to create a deterministic account (an advanced kind of implicit account)
 
 For example, `bob.near` can bundle the following actions in a single transaction:
 - Create the account `contract.bob.near`

--- a/protocol/transactions/transaction-execution.mdx
+++ b/protocol/transactions/transaction-execution.mdx
@@ -146,3 +146,4 @@ On a valid transaction, the `nonce` value should follow these rules:
 - A transaction is accepted only if the `nonce` value is in the range of:
   - `[(current_nonce_of_access_key + 1) .. (block_height * 10^6)]`
 - Once a transaction is accepted, the access key's `nonce` is set to the `nonce` value of the included transaction
+- [Gas keys](/protocol/accounts-contracts/access-keys#gas-keys) hold one nonce per lane (up to 1,024 lanes); a transaction signed with a gas key selects a lane with its `nonce_index`, and the rules above apply to that lane's nonce independently of all other lanes

--- a/tools/cli.mdx
+++ b/tools/cli.mdx
@@ -298,6 +298,38 @@ The same `--signature-scheme` flag is available on the `account create-account f
 The interactive key picker only lists `ed25519` and `secp256k1` keys. A post-quantum `ml-dsa-65` key is stored on-chain only as a hash, so its full public key can't be read back from the network — to delete one, pass the full `ml-dsa-65:<base58>` key explicitly to the `public-keys` argument of `near account delete-keys` (the full command form shown above).
 </Note>
 
+### Gas keys
+
+[Gas keys](/protocol/accounts-contracts/access-keys#gas-keys) are access keys with their own prepaid gas balance and up to 1,024 parallel nonces. The `add-key` command can create them through the `grant-gas-key-full-access` and `grant-gas-key-function-call` modes, and dedicated commands manage their balance and nonces.
+
+A gas key is always created empty — fund it with `fund-gas-key` before using it:
+
+```bash
+export ACCOUNT_ID=bob.testnet
+
+# Create a full-access gas key with 8 parallel nonces
+near account add-key $ACCOUNT_ID grant-gas-key-full-access --num-nonces 8 autogenerate-new-keypair save-to-keychain network-config testnet sign-with-keychain send
+
+# Transfer 5 NEAR from the account into the gas key's balance
+near account fund-gas-key $ACCOUNT_ID ed25519:CXqAs8c8kZz81josLw82RQsnZXk8CAdUo7jAuN7uSht2 '5 NEAR' network-config testnet sign-with-keychain send
+
+# View the current nonce of each of the key's lanes
+near account view-gas-key-nonces $ACCOUNT_ID ed25519:CXqAs8c8kZz81josLw82RQsnZXk8CAdUo7jAuN7uSht2 network-config testnet now
+
+# Move 2 NEAR from the gas key's balance back to the account
+near account withdraw-from-gas-key $ACCOUNT_ID ed25519:CXqAs8c8kZz81josLw82RQsnZXk8CAdUo7jAuN7uSht2 '2 NEAR' network-config testnet sign-with-keychain send
+```
+
+To sign a transaction with a gas key, pass `--nonce-index` to the signing option to choose which nonce lane to use (defaults to lane `0`):
+
+```bash
+near tokens $ACCOUNT_ID send-near alice.testnet '1 NEAR' network-config testnet sign-with-keychain --nonce-index 3 send
+```
+
+<Note>
+Deleting a gas key **burns** any balance left on it, and fails if the balance exceeds 1 NEAR — withdraw first with `withdraw-from-gas-key`, then delete with the regular `delete-keys` command. Signing meta transactions (`--sign-as-delegate-action`) with a gas key is not supported by the CLI yet.
+</Note>
+
 ## Tokens
 
 This will allow you to manage your token assets such as NEAR, FTs and NFTs.

--- a/tools/cli.mdx
+++ b/tools/cli.mdx
@@ -326,8 +326,10 @@ To sign a transaction with a gas key, pass `--nonce-index` to the signing option
 near tokens $ACCOUNT_ID send-near alice.testnet '1 NEAR' network-config testnet sign-with-keychain --nonce-index 3 send
 ```
 
+Gas keys also work with **meta transactions**. The CLI signs as a delegate action when the selected network connection has a relayer configured (a `meta_transaction_relayer_url`, set on the connection with `near config add-connection`). Signing such a transaction with `--nonce-index` then produces a [`DelegateV2`](/protocol/transactions/meta-tx#delegatev2-meta-transactions-with-gas-keys) delegate action bound to that nonce lane, which the relayer wraps and pays for.
+
 <Note>
-Deleting a gas key **burns** any balance left on it, and fails if the balance exceeds 1 NEAR — withdraw first with `withdraw-from-gas-key`, then delete with the regular `delete-keys` command. Signing meta transactions (`--sign-as-delegate-action`) with a gas key is not supported by the CLI yet.
+Deleting a gas key **burns** any balance left on it, and fails if the balance exceeds 1 NEAR — withdraw first with `withdraw-from-gas-key`, then delete with the regular `delete-keys` command. Gas-key meta transactions are supported for all software signers; Ledger is the exception, since the device firmware cannot yet produce a `DelegateV2` signature.
 </Note>
 
 ## Tokens

--- a/web3-apps/tutorials/meta-transactions.mdx
+++ b/web3-apps/tutorials/meta-transactions.mdx
@@ -108,7 +108,9 @@ When running a relayer that handles a large number of transactions, you will qui
 
 When multiple transactions are sent from the same access key simultaneously, their nonces might collide. Imagine the relayer creates 3 transactions `Tx1`, `Tx2`, `Tx3` and send them in very short distance from each other, and lets assume that `Tx3` has the largest nonce. If `Tx3` ends up being processed before `Tx1` (because of network delays, or a node picks `Tx3` first), then `Tx3` will execute, but `Tx1` and `Tx2` will fail, because they have smaller nonce!
 
-One way to mitigate this is to sign each transaction with a different key. Adding multiple full access keys to the NEAR account used for relaying (up to 20 keys can make a significant difference) will help.
+Since nearcore 2.13, the native solution to this problem is a [gas key](/protocol/accounts-contracts/access-keys#gas-keys): a single access key with up to **1,024 independent nonce lanes** and its own prepaid gas balance. The relayer signs each concurrent transaction on a different lane (via the transaction's `nonce_index`), so nonces can never collide, and the gas spent on relaying is isolated from the account's main balance. This replaces the key-rotation workaround below with one key to manage.
+
+On earlier versions, the way to mitigate this is to sign each transaction with a different key. Adding multiple full access keys to the NEAR account used for relaying (up to 20 keys can make a significant difference) will help.
 
 <Accordion title="Adding keys">
 


### PR DESCRIPTION
## Summary

Documents two protocol features stabilized in [nearcore 2.13](https://github.com/near/nearcore/releases/tag/2.13.0) (protocol version 86):

- **Gas keys** ([NEP-611](https://github.com/near/NEPs/pull/611)): access keys with a prepaid gas balance and up to 1,024 parallel nonce lanes. Transactions signed with a gas key pay gas from the key's balance instead of the account's balance, and each nonce lane advances independently — enabling high-volume parallel transaction submission from a single key.
- **DelegateV2 meta transactions**: a second version of the delegate action whose nonce can be a gas-key nonce (`nonce` + `nonce_index`), so meta transactions can be signed on a gas key's nonce lanes and relayers can pay gas from their own gas keys.

## Changes

Following the approach used for ML-DSA-65 (#3061): a canonical section on the relevant concept page plus cross-links on practical pages — no new pages.

- `protocol/accounts-contracts/access-keys.mdx` — new **Gas Keys** section (canonical home): what they are, lifecycle (create empty → fund → use → withdraw → delete), payment/refund semantics, nonce lanes, tooling pointers
- `protocol/transactions/meta-tx.mdx` — new **DelegateV2** section: JSON shape, nonce-variant/key matching rules, what gas keys contribute on each side of the relay, V1 coexistence, tooling
- `api/rpc/contracts.mdx` — new **View Gas Key Nonces** reference (`view_gas_key_nonces` query), gas-key permission shape in `view_access_key`, quick-reference and error-table rows
- `tools/cli.mdx` — **Gas keys** subsection covering `grant-gas-key-full-access --num-nonces`, `fund-gas-key`, `withdraw-from-gas-key`, `view-gas-key-nonces`, `--nonce-index` signing, and gas-key meta-transaction signing on relayer-configured connections
- `protocol/transactions/transaction-anatomy.mdx` — `TransferToGasKey`/`WithdrawFromGasKey` in the actions list, `nonce_index` in the nonce info
- `protocol/transactions/gas.mdx`, `protocol/transactions/transaction-execution.mdx` — notes on gas-key payment and per-lane nonce rules
- `web3-apps/tutorials/meta-transactions.mdx` — gas keys as the native replacement for the multi-key nonce-rotation workaround in the relayer tutorial

## Notes for reviewers

- All protocol claims were verified against the nearcore 2.13 source (actions, RPC types, refund routing in the runtime, `MAX_NONCES_FOR_GAS_KEY`, protocol gating in `85.yaml`) and NEP-611 v1.2.2.
- On protocol version: the feature gate lives at v85 in the source (hence the `85.yaml` runtime-config file), but the 2.13.0 release upgrades mainnet from v84 **directly to v86** — v85 existed only in the release candidates, so no mainnet/testnet block ever runs at 85. The docs therefore cite **v86** as the version integrators will observe the features live at. (Thanks to the Codex review for flagging this.)
- Tooling is live as of nearcore 2.13: gas keys + DelegateV2 are supported in `near-kit` (TypeScript, incl. a `view_gas_key_nonces` reader), `near-kit-rs` (Rust), and the NEAR CLI (`near-cli-rs`: gas-key key management + gas-key meta-transaction signing on relayer-configured connections). Docs examples use the CLI and protocol-level JSON. Ledger is the one exception for gas-key meta transactions (firmware can't produce a `DelegateV2` signature yet). `near-api-js` still has only generated RPC types, so it is not showcased.
- The NEP-611 Pending Transaction Queue is not documented here — it is SPICE-only machinery and dormant in 2.13.
