### PR TITLE
docs(rpc): document query-only json-rpc batching

### DIFF
--- a/api/rpc/batching.mdx
+++ b/api/rpc/batching.mdx
@@ -1,0 +1,141 @@
+---
+title: "Query Batching"
+icon: layer-group
+description: "Send multiple read-only NEAR queries in one JSON-RPC request."
+sidebarTitle: "Query Batching"
+---
+
+Normally, one HTTP request contains one JSON-RPC request object. Batching changes only the outer envelope: put one or more ordinary request objects inside square brackets (`[...]`) and separate them with commas. Each inner request keeps its own method, parameters, and ID, and the server returns the corresponding responses as an array. Notifications still have no response entry.
+
+This page documents nearcore's query-only contribution to the [JSON-RPC 2.0 batch specification](https://www.jsonrpc.org/specification#batch). Recent nearcore nodes accept these arrays at the root `POST /` endpoint when the operator enables them. Batching is enabled by default in nearcore, but providers can disable it.
+
+Only the exact, case-sensitive `query` method executes in a batch. Other requests that include an ID, including `send_tx`, `broadcast_tx_async`, and `broadcast_tx_commit`, return `-32601` (method not found). Submit transactions and call every other RPC method with individual requests.
+
+<Note>
+  Public providers can deploy different nearcore versions, disable batching, or apply different limits, gateways, and request policies. Confirm availability, limits, and how a provider accounts for each batch entry before relying on batching.
+</Note>
+
+## Consistent block-pinned queries
+
+Entries are independent and may run concurrently. A batch has no execution ordering, is not atomic, and does not automatically read from one snapshot. The server currently preserves response order as an implementation detail, but clients must correlate responses by `id`.
+
+When the queries must observe the same finalized state, first resolve one final block with an individual `block` request. Then pass its hash as `block_id` in every query. This localnet example queries the preconfigured `test.near` and `near` accounts and decodes the response array by ID:
+
+```bash
+RPC_URL=${RPC_URL:-http://127.0.0.1:3030/}
+
+BLOCK_ID=$(
+  curl -fsS "$RPC_URL" \
+    -H 'Content-Type: application/json' \
+    --data-binary \
+      '{"jsonrpc":"2.0","id":"final-block","method":"block","params":{"finality":"final"}}' \
+  | jq -er '.result.header.hash'
+)
+
+jq -cn --arg block_id "$BLOCK_ID" '
+  [
+    {
+      jsonrpc: "2.0",
+      id: "test.near",
+      method: "query",
+      params: {
+        request_type: "view_account",
+        account_id: "test.near",
+        block_id: $block_id
+      }
+    },
+    {
+      jsonrpc: "2.0",
+      id: "near",
+      method: "query",
+      params: {
+        request_type: "view_account",
+        account_id: "near",
+        block_id: $block_id
+      }
+    }
+  ]' \
+| curl -fsS "$RPC_URL" \
+    -H 'Content-Type: application/json' \
+    --data-binary @- \
+| jq -e --arg block_id "$BLOCK_ID" '
+    INDEX(.id) as $responses
+    | ["test.near", "near"]
+    | map(
+        $responses[.] as $response
+        | if $response == null then
+            error("missing response for " + .)
+          elif $response.error then
+            error(($response.error | tostring))
+          elif $response.result.block_hash != $block_id then
+            error("response was not read at the pinned block")
+          else
+            {
+              id: $response.id,
+              block_hash: $response.result.block_hash,
+              amount: $response.result.amount,
+              locked: $response.result.locked
+            }
+          end
+      )'
+```
+
+## IDs and notifications
+
+- String, number, and explicit `null` IDs are echoed in responses. An omitted `id` makes the entry a notification; an explicit `"id": null` does not.
+- Boolean, array, and object IDs are invalid and receive `-32600` with `"id": null`.
+- Duplicate IDs are accepted, but make correlation ambiguous. Use a unique ID for every request that expects a response.
+- Omitted or `null` `params` are treated as absent. Object and array values reach normal query parsing; other primitive values are invalid and receive `-32600`.
+- A `query` notification executes, but the server suppresses its result. A notification for any other method is silently ignored.
+- A batch containing only valid notifications returns HTTP `204` with no body.
+
+Invalid members, nested batches, and response objects sent by a client each receive their own `-32600` response. They do not prevent valid sibling queries from running.
+
+## HTTP behavior and errors
+
+When batching is enabled, a valid, nonempty batch with at least one response entry returns HTTP `200`, even when individual entries contain RPC errors. Clients must inspect each response's `result` or `error` field.
+
+| HTTP status | Meaning |
+| --- | --- |
+| `200` | The batch produced at least one response, or the node returned a batch-level server error. |
+| `204` | Every entry was a valid notification, so the response has no body. |
+| `400` | The JSON was malformed or the batch was an empty array. |
+| `413` | The HTTP request body exceeded the node's body-size limit. |
+| `415` | The request did not use a supported JSON content type. |
+
+| Error code | Meaning |
+| ---: | --- |
+| `-32700` | Parse error: the body is malformed JSON or has trailing data. |
+| `-32600` | Invalid request: for example, an invalid member, ID, nested batch, client-sent response, or empty array. |
+| `-32601` | Method not found: a request with an ID used a method other than exact `query`. |
+| `-32005` | `batch requests are not supported by this server`: batching is disabled on this node, so nothing in the batch executes. |
+| `-32010` | The batch contains more entries than `batch_size_limit`; nothing in the batch executes. |
+| `-32011` | The serialized aggregate response exceeds `batch_response_size_limit`; all entries are drained and the aggregate is replaced by one non-array error response. |
+
+Malformed JSON and an empty array produce one non-array error response with HTTP `400`. A disabled node and the two limit errors also replace the batch with one non-array response whose ID is `null` and HTTP `200`.
+
+Validation uses this order: unsupported content type (`415`), oversized HTTP body (`413`), malformed or trailing JSON (`-32700`), unchanged handling for a non-array request, empty array (`-32600`), disabled batching (`-32005`), and too many entries (`-32010`). Entries execute only after all of these checks pass.
+
+## Node limits
+
+Node operators configure batching under `rpc` in `config.json`:
+
+| Setting | Default | Behavior |
+| --- | ---: | --- |
+| `enable_batch_requests` | `true` | Enables query batches. A disabled node returns `-32005` before query-domain parsing or dispatching a valid nonempty batch. |
+| `limits_config.json_payload_max_size` | 10 MiB | Maximum HTTP request body. An oversized body receives HTTP `413`. |
+| `limits_config.batch_size_limit` | 100 entries | Must be positive. An oversized batch receives `-32010` before any entry runs. |
+| `limits_config.batch_concurrency_limit` | 16 | Maximum query-entry concurrency within each individual batch; the value must be positive. |
+| `limits_config.batch_response_size_limit` | 10 MiB | Maximum serialized aggregate response size; the value must be positive. An oversized response is replaced by `-32011`. |
+
+The fields have backward-compatible defaults when omitted. Changing one requires restarting the node.
+
+The concurrency setting is not a node-wide admission limit. Simultaneous batches can multiply outstanding work, and individual RPC requests are not counted against it. A gateway that charges only per HTTP request will undercount batch work. Operators should charge every top-level entry, including notifications, and ideally account for query type or cost. If a gateway cannot inspect arrays, combine a conservative batch-size limit with connection and HTTP-request rate limits.
+
+There is no deadline around a whole batch. Individual operations keep their existing timeout behavior, and disconnecting does not guarantee that work already queued by the node will stop. The response-size limit bounds only the serialized responses retained for the aggregate; it does not bound query compute, queue depth, or transient memory used while admitted query parameters are decoded or an individual result is produced.
+
+Self-hosted nodes expose `near_rpc_batch_requests_total`, `near_rpc_batch_request_entries`, `near_rpc_batch_entries_total`, `near_rpc_batch_processing_time`, `near_rpc_batch_response_size_bytes`, `near_rpc_batch_requests_in_flight`, and `near_rpc_batch_query_entries_in_flight` at `/metrics`. These fixed-cardinality series separate batch-envelope behavior from the existing per-method metrics; the response-size histogram observes successful response arrays. Processing-time and in-flight measurements begin after the batch passes syntax, kill-switch, and size-limit admission checks.
+
+<Warning>
+  Never load test shared public RPC endpoints. Benchmark only a node you operate or an endpoint whose operator has explicitly authorized the test.
+</Warning>

--- a/api/rpc/introduction.mdx
+++ b/api/rpc/introduction.mdx
@@ -20,15 +20,15 @@ NEAR Protocol provides multiple ways to interact with the network — from low-l
 
 ## RPC API
 
-NEAR exposes a JSON-RPC 2.0 API for programmatic access to the network. All requests are `POST` to a provider endpoint, with the method name encoded in the URL path.
+NEAR exposes a JSON-RPC 2.0 API for programmatic access to the network. Send requests with `POST` to the root of a provider endpoint and put the method name in the JSON request body.
 
 ```bash
-curl -X POST https://rpc.mainnet.near.org/status \
+curl -X POST https://rpc.mainnet.near.org/ \
   -H "Content-Type: application/json" \
-  -d '{}'
+  -d '{"jsonrpc":"2.0","id":"status","method":"status","params":[]}'
 ```
 
-See [RPC Providers](/api/rpc/providers) for the full list of public endpoints.
+See [RPC Providers](/api/rpc/providers) for the full list of public endpoints. When enabled by its operator, a recent nearcore node can also accept multiple read-only `query` calls in one request; see [Query Batching](/api/rpc/batching) for its scope and availability caveats.
 
 ## Available Methods
 

--- a/api/rpc/providers.mdx
+++ b/api/rpc/providers.mdx
@@ -54,13 +54,19 @@ FastNear maintains a [comprehensive dashboard](https://grafana.fastnear.com/publ
 
 ## Making requests
 
-All endpoints accept JSON-RPC 2.0 `POST` requests. The NEAR RPC uses a non-standard format where the method name is encoded in the URL path rather than the request body.
+Send JSON-RPC 2.0 requests with `POST` to the root of the provider endpoint. Put the method and parameters in the JSON request body.
 
 ```bash
-curl -X POST https://rpc.mainnet.near.org/status \
+curl -X POST https://rpc.mainnet.near.org/ \
   -H "Content-Type: application/json" \
-  -d '{}'
+  -d '{"jsonrpc":"2.0","id":"status","method":"status","params":[]}'
 ```
+
+Recent nearcore nodes support [query-only JSON-RPC batching](/api/rpc/batching), but public providers can run different nearcore versions, disable batching, or apply different limits, gateways, and request policies. Confirm batch availability and limits before depending on it. Do not assume that one HTTP batch consumes one request from a quota: providers may count every entry or use a method-specific compute cost.
+
+<Warning>
+  Never load test a shared public endpoint. Run performance or high-volume batch tests only against a node you operate or an endpoint whose operator has explicitly authorized the test.
+</Warning>
 
 ## Run your own node
 

--- a/docs.json
+++ b/docs.json
@@ -598,6 +598,7 @@
             "group": " ",
             "pages": [
               "api/rpc/introduction",
+              "api/rpc/batching",
               "api/rpc/providers",
               "api/rpc/transactions",
               "api/rpc/block-chunk",


### PR DESCRIPTION
## In plain language

JSON-RPC batching changes only the outer envelope. Instead of posting one request object at a time, a client wraps comma-separated request objects in square brackets (`[...]`) and sends them together. Each entry keeps its own method, parameters, and ID, and clients correlate the returned responses by ID.

## What this PR is part of

This is the documentation half of a coordinated nearcore change adding query-only JSON-RPC 2.0 batching. The first version deliberately executes only the exact, case-sensitive `query` method; transaction submission and all other RPC methods remain single-request operations. Batch entries are independent rather than atomic or snapshot-consistent, so the guide shows how to resolve one final block and pin every query to it.

This PR documents that contract, notifications, limits and errors, the operator kill switch, metrics and operational caveats, and provider rollout variability. It also corrects the introduction and provider pages to show canonical JSON-RPC requests sent to the root `POST /` endpoint.

## Delivery sequence and contingencies

1. The small prerequisite [nearcore #16083](https://github.com/near/nearcore/pull/16083) is open and awaiting review. It fixes an unrelated arm64 test-loop clippy failure that must land before the batching branch can pass nearcore's required all-features, all-targets clippy gate without carrying an unrelated fix.
2. This Docs PR is open early so the public contract can be reviewed and adjusted before the implementation merges. It should remain open until the companion nearcore PR exists and the two PRs are cross-linked; the intended merge order is Docs immediately before, or in coordination with, nearcore.
3. The nearcore feature PR is not open yet. Its implementation and local validation are complete, but its final provenance commit will be created only after #16083 merges. At that point we will rebase onto live nearcore master, repeat the targeted and full JSON-RPC suites, regenerate and compare OpenAPI, rebuild and smoke-test localnet, run the exact full clippy gate, and validate the final SHA on one loopback-only, fully synced testnet RPC node running on an M4 Pro Mac mini. If those gates pass, we will open the ready nearcore PR and link it here and to [nearcore #10528](https://github.com/near/nearcore/issues/10528).

If nearcore master advances during that process, the branch will be rebased and the affected validation repeated. If validation changes the public behavior, this documentation will be updated before either PR merges. If #16083 is delayed, this PR can still receive editorial review, but it should not merge as an unsupported standalone promise.

Node-wide weighted admission control and transaction batching are deliberately separate follow-ups, not hidden prerequisites for this query-only version.