### PR TITLE
docs: add Homebrew install option for NEAR CLI

### DIFF
--- a/getting-started/create-account.mdx
+++ b/getting-started/create-account.mdx
@@ -47,7 +47,40 @@ Need `testnet` funds? try using one of our [faucets](/getting-started/faucet)
 
 When developing smart contracts you will expend lots of time interacting with the NEAR blockchain through the command line interface (CLI).
 
-First, you will need to install the NEAR CLI, for which multiple installation methods are available (npm, Homebrew, Cargo, and standalone installers) - pick your favorite from the [installation guide](/tools/cli#installation).
+First, you will need to install the [NEAR CLI](/tools/cli#installation):
+
+<Tabs>
+  <Tab title="npm">
+
+  ```bash
+  npm install -g near-cli-rs@latest
+  ```
+  </Tab>
+  <Tab title="Homebrew">
+
+  ```bash
+  brew install near
+  ```
+  </Tab>
+  <Tab title="Cargo">
+
+  ```
+  $ cargo install near-cli-rs
+  ```
+  </Tab>
+  <Tab title="Mac and Linux (binaries)">
+
+  ```bash
+  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/latest/download/near-cli-rs-installer.sh | sh
+  ```
+  </Tab>
+  <Tab title="Windows (binaries)">
+
+  ```bash
+  irm https://github.com/near/near-cli-rs/releases/latest/download/near-cli-rs-installer.ps1 | iex
+  ```
+  </Tab>
+</Tabs>
 
 Once you have the CLI installed, you can create a new account using the following command:
 

--- a/getting-started/create-account.mdx
+++ b/getting-started/create-account.mdx
@@ -47,34 +47,7 @@ Need `testnet` funds? try using one of our [faucets](/getting-started/faucet)
 
 When developing smart contracts you will expend lots of time interacting with the NEAR blockchain through the command line interface (CLI).
 
-First, you will need to install the [NEAR CLI](/tools/cli#installation):
-
-<Tabs>
-  <Tab title="npm">
-
-  ```bash
-  npm install -g near-cli-rs@latest
-  ```
-  </Tab>
-  <Tab title="Cargo">
-
-  ```
-  $ cargo install near-cli-rs
-  ```
-  </Tab>
-  <Tab title="Mac and Linux (binaries)">
-
-  ```bash
-  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/latest/download/near-cli-rs-installer.sh | sh
-  ```
-  </Tab>
-  <Tab title="Windows (binaries)">
-
-  ```bash
-  irm https://github.com/near/near-cli-rs/releases/latest/download/near-cli-rs-installer.ps1 | iex
-  ```
-  </Tab>
-</Tabs>
+First, you will need to install the NEAR CLI, for which multiple installation methods are available (npm, Homebrew, Cargo, and standalone installers) - pick your favorite from the [installation guide](/tools/cli#installation).
 
 Once you have the CLI installed, you can create a new account using the following command:
 

--- a/tools/cli.mdx
+++ b/tools/cli.mdx
@@ -14,6 +14,11 @@ The NEAR [Command Line Interface](https://github.com/near/near-cli-rs) (CLI) is 
     npm install -g near-cli-rs@latest
     ```
   </Tab>
+  <Tab title="Homebrew">
+    ```bash
+    brew install near
+    ```
+  </Tab>
   <Tab title="Cargo">
     ```bash
     cargo install near-cli-rs

--- a/web3-apps/tutorials/localnet/run.mdx
+++ b/web3-apps/tutorials/localnet/run.mdx
@@ -17,7 +17,7 @@ Also check the [localnet tutorial](https://github.com/near/mpc/blob/main/docs/lo
 
 Before we begin, make sure you have a few essential tools installed.
 
-- [near-cli-rs](https://github.com/near/near-cli-rs) - the CLI for interacting with the NEAR blockchain;
+- [NEAR CLI](/tools/cli#installation) - the CLI for interacting with the NEAR blockchain;
 - [cargo-near](https://github.com/near/cargo-near) - the CLI that simplifies building/deploying Rust smart contracts.
 
 ### Walkthrough


### PR DESCRIPTION
## Summary

- add a Homebrew tab (`brew install near`) to the NEAR CLI installation page, now that the `near` formula is in Homebrew/core (near/devex#56)
- add the same Homebrew tab to the inline install options on the account-creation guide (kept inline so the getting-started flow stays self-contained)
- point the localnet tutorial prerequisite at the installation guide instead of the GitHub repo

## Validation

- `npx --yes mint validate`
- `npx --yes mint broken-links`