### PR TITLE
docs(intents): add independent fee benchmark card to Resources

### DIFF
--- a/chain-abstraction/intents/overview.mdx
+++ b/chain-abstraction/intents/overview.mdx
@@ -50,4 +50,7 @@ If the quote from the Market Maker is accepted, the intent is executed by callin
 	<Card title="near-intents.org (Live Site)" icon="globe" href="https://near-intents.org">
 		Try the live demo application showcasing token swaps.
 	</Card>
+	<Card title="Independent Fee Benchmark" icon="chart-bar" href="https://openchainbench.com/benchmarks/bridge-fee">
+		Compare NEAR Intents against other bridges on effective USDC transfer costs, measured independently across Solana, Base, and Arbitrum corridors.
+	</Card>
 </CardGroup>


### PR DESCRIPTION
Adds one new card to the Resources CardGroup at the bottom of `chain-abstraction/intents/overview.mdx`, linking to an independent third-party benchmark that compares NEAR Intents against other cross-chain bridges on effective USDC transfer costs.

**Why this fits:**
- The Resources section is exactly where readers look for supporting material after reading the overview
- Independent cost verification is useful context for developers evaluating NEAR Intents vs alternatives
- Factually, NEAR Intents currently leads the OpenChainBench bridge-fee benchmark at 0.058% (vs Relay 0.13%, Across 0.14%, LI.FI 0.42%, deBridge 0.90% at $300 USDC notional across Solana/Base/Arbitrum corridors)

**What's added:**
- Single `<Card>` element inside the existing `<CardGroup cols={2}>`, matching the style of the four existing cards
- One external link to https://openchainbench.com/benchmarks/bridge-fee

**About OpenChainBench:** independent open-source project benchmarking blockchain infrastructure (RPC providers, bridges, aggregators, execution quality). Data published under CC BY 4.0, harness open sourced on GitHub, no affiliation with any bridge provider including NEAR Intents.

**Disclosure:** I contribute to OpenChainBench. Happy to reword or drop entirely if this doesn't fit editorial guidelines.