### PR TITLE
Add node101 as RPC provider

### DIFF
--- a/api/rpc/providers.mdx
+++ b/api/rpc/providers.mdx
@@ -25,6 +25,7 @@ FastNear maintains a [comprehensive dashboard](https://grafana.fastnear.com/publ
 | [Intear RPC](https://intea.rs/) | `https://rpc.intea.rs` | ✅ | ❌ | ✅ | Not published | ❌ |
 | [Lava Network](https://www.lavanet.xyz/lava-public-rpc) | N/A | ❌ | ✅ | ❌ | — | ✅ |
 | [Lavender.Five Nodes](https://www.lavenderfive.com/tools/near/overview) | N/A | ❌ | ❌ | ✅ | Not published | ✅ |
+| [node101](https://node101.io/en/rpc/near) | N/A | ❌ | Paid Only | ❌ | — | ✅ |
 | [NodeReal](https://nodereal.io/api-marketplace/near-rpc) | `https://near-mainnet.nodereal.io/v1/{api-key}` | ❌ | ❌ | ✅ | [100M CU/month](https://nodereal.io/api-marketplace/near-rpc) | ✅ |
 | [NOWNodes](https://nownodes.io/near) | `https://near.nownodes.io/{api-key}` | ❌ | ❌ | ✅ | [100K req/month](https://nownodes.io/near) | ✅ |
 | [QuickNode](https://www.quicknode.com/chains/near) | N/A | ❌ | ✅ | ✅ | [15 req/s](https://www.quicknode.com/pricing) | ✅ |
@@ -43,6 +44,7 @@ FastNear maintains a [comprehensive dashboard](https://grafana.fastnear.com/publ
 | [dRPC](https://drpc.org/chainlist/near-testnet-rpc) | `https://near-testnet.drpc.org` | ✅ | ❌ | ✅ | [~2,100 CU/s](https://drpc.org/docs/howitworks/ratelimiting) | ✅ |
 | [Intear RPC](https://intea.rs/) | `https://testnet-rpc.intea.rs` | ✅ | ❌ | ✅ | Not published | ❌ |
 | [Lava Network](https://www.lavanet.xyz/lava-public-rpc) | N/A | ❌ | ✅ | ❌ | — | ✅ |
+| [node101](https://node101.io/en/rpc/near) | N/A | ❌ | Paid Only | ❌ | — | ✅ |
 | [QuickNode](https://www.quicknode.com/chains/near) | N/A | ❌ | ✅ | ✅ | [15 req/s](https://www.quicknode.com/pricing) | ✅ |
 | [Tatum](https://tatum.io/chain/near/) | N/A | ❌ | ❌ | ✅ | [3 req/s](https://docs.tatum.io/docs/plans-limits) | ✅ |
 | [ZAN](https://zan.top/service/apikeys) | `https://api.zan.top/node/ws/v1/near/testnet` | ❌ | ❌ | ✅ | [~20 req/s](https://docs.zan.top/docs/resource-pricing) | ✅ |


### PR DESCRIPTION
Add node101 as an RPC provider to both the Mainnet and Testnet tables.

Source: https://node101.io/en/rpc/near